### PR TITLE
add --port (-r) as a command line option. also added a port check to …

### DIFF
--- a/cli/cmd.js
+++ b/cli/cmd.js
@@ -91,8 +91,6 @@ const setup = function setup() {
       if(cluster.isMaster && options.port){
         portastic.test(options.port)
           .then(function(isAvailable){
-            console.log('Port ' + options.port + ' is %s', isAvailable ? 'available' : 'not available');
-            
             if(!isAvailable) {
               options.error('port is not available.');
               process.exit(1);

--- a/cli/cmd.js
+++ b/cli/cmd.js
@@ -7,7 +7,11 @@ const run = require('./lib/gateway')();
 const keyGenerator = require('./lib/key-gen')();
 const prompt = require('cli-prompt');
 const cluster = require('cluster')
-const init = require('./lib/init')
+const init = require('./lib/init');
+var portastic = require('portastic');
+
+const configLocations = require('../config/locations');
+
 
 const setup = function setup() {
   commander
@@ -73,6 +77,7 @@ const setup = function setup() {
     .option('-c, --cluster', 'will cluster the server')
     .option('-p, --processes <processes>', 'number of processes to start, defaults to # of cores')
     .option('-d, --pluginDir <pluginDir>','absolute path to plugin directory')
+    .option('-r, --port <portNumber>','override port in the config.yaml file')
     .description('start the gateway based on configuration')
     .action((options)=>{
       options.error = optionError;
@@ -81,7 +86,20 @@ const setup = function setup() {
       options.org = options.org || process.env.EDGEMICRO_ORG;
       options.env = options.env || process.env.EDGEMICRO_ENV;
       options.cluster =  options.cluster || process.env.EDGEMICRO_CLUSTER ;
-      options.processes =  options.processes || process.env.EDGEMICRO_PROCESSES ;
+      options.processes =  options.processes || process.env.EDGEMICRO_PROCESSES;
+
+      if(cluster.isMaster && options.port){
+        portastic.test(options.port)
+          .then(function(isAvailable){
+            console.log('Port ' + options.port + ' is %s', isAvailable ? 'available' : 'not available');
+            
+            if(!isAvailable) {
+              options.error('port is not available.');
+              process.exit(1);
+            }
+            
+          });
+      }
       if (!options.key ) {return  options.error('key is required');}
       if (!options.secret ) {return  options.error('secret is required');}
       if (!options.org ) { return  options.error('org is required'); }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "tmp": "0.0.28",
     "util": "^0.10.3",
     "uuid": "^2.0.1",
-    "xml2js": "^0.4.16"
+    "xml2js": "^0.4.16",
+    "portastic": "^1.0.1"
+   
   },
   "devDependencies": {
     "gulp": "^3.8.11",


### PR DESCRIPTION
I added a new command line option to override the port in the config.yaml file.  This will save the new port to the cached-config.yaml file.  The default.yaml file will remain as the standard port (8000).  

i.e
./edgemicro start -o org -e test -k key -s secret -c -p 2 --port 8002

i.e
./edgemicro start -o org -e test -k key -s secret --port 8002


I also added a portastic to test if the port was open before it continued. If the port is not open then it generates an error and exits.  
./edgemicro start -o org -e test -k key -s secret --port 8001

Port 8001 is not available
port is not available.

  Usage: start [options]

  start the gateway based on configuration

  Options:

    -h, --help                   output usage information
    -o, --org <org>              the organization
    -e, --env <env>              the environment
    -k, --key <key>              key for authenticating with Edge
    -s, --secret <secret>        secret for authenticating with Edge
    -c, --cluster                will cluster the server
    -p, --processes <processes>  number of processes to start, defaults to # of cores
    -d, --pluginDir <pluginDir>  absolute path to plugin directory
    -r, --port <portNumber>      override port in the config.yaml file

If you don't include the --port option then it will listen on the default port listed in the config.yaml file.  