### PR TITLE
"overrides" for Cloud Foundry

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -35,3 +35,12 @@ headers:
 oauth:
   allowNoAuthorization: false
   allowInvalidAuthorization: false
+
+overrides:
+- name: cloud-foundry
+  env:
+    flag: VCAP_APPLICATION
+    port: PORT
+  headers:
+    retarget: x-cf-forwarded-url
+  log_to_console: true

--- a/lib/agent-config.js
+++ b/lib/agent-config.js
@@ -20,6 +20,8 @@ const getConfigStart = function getConfigStart(options, cb) {
   fs.exists(options.target, (exists) => {
     if (exists) {
       const config = edgeConfig.load({ source: options.target });
+      // TODO-CF port override
+      config.edgemicro.port = process.env.PORT || config.edgemicro.port;
       startServer(options.keys, options.pluginDir,config, cb);
     } else {
       return cb(options.target+" must exist")

--- a/lib/agent-config.js
+++ b/lib/agent-config.js
@@ -20,8 +20,6 @@ const getConfigStart = function getConfigStart(options, cb) {
   fs.exists(options.target, (exists) => {
     if (exists) {
       const config = edgeConfig.load({ source: options.target });
-      // TODO-CF port override
-      config.edgemicro.port = process.env.PORT || config.edgemicro.port;
       startServer(options.keys, options.pluginDir,config, cb);
     } else {
       return cb(options.target+" must exist")

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,8 @@
+---
+applications:
+- name: edgemicro-app
+  memory: 256M
+  instances: 1
+  host: edgemicro-app
+  path: .
+  buildpack: nodejs_buildpack

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,2889 +1,3783 @@
 {
   "name": "edgemicro",
-  "version": "2.0.10",
+  "version": "2.0.11-pcf.0",
   "dependencies": {
-    "ansi-regex": {
-      "version": "2.0.0",
-      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-    },
-    "ansi-styles": {
-      "version": "2.2.1",
-      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-    },
-    "apigee-access": {
-      "version": "1.3.0",
-      "from": "https://registry.npmjs.org/apigee-access/-/apigee-access-1.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/apigee-access/-/apigee-access-1.3.0.tgz"
-    },
     "apigeetool": {
       "version": "0.6.3",
-      "from": "https://registry.npmjs.org/apigeetool/-/apigeetool-0.6.3.tgz",
+      "from": "apigeetool@>=0.6.3 <0.7.0",
       "resolved": "https://registry.npmjs.org/apigeetool/-/apigeetool-0.6.3.tgz",
       "dependencies": {
+        "cli-table": {
+          "version": "0.3.1",
+          "from": "cli-table@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+          "dependencies": {
+            "colors": {
+              "version": "1.0.3",
+              "from": "colors@1.0.3",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+            }
+          }
+        },
+        "mustache": {
+          "version": "2.2.1",
+          "from": "mustache@>=2.1.3 <3.0.0",
+          "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.2.1.tgz"
+        },
+        "node-unzip-2": {
+          "version": "0.2.1",
+          "from": "node-unzip-2@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/node-unzip-2/-/node-unzip-2-0.2.1.tgz",
+          "dependencies": {
+            "fstream": {
+              "version": "0.1.31",
+              "from": "fstream@>=0.1.21 <0.2.0",
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "3.0.8",
+                  "from": "graceful-fs@>=3.0.2 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "pullstream": {
+              "version": "0.4.1",
+              "from": "pullstream@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
+              "dependencies": {
+                "over": {
+                  "version": "0.0.5",
+                  "from": "over@>=0.0.5 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz"
+                },
+                "slice-stream": {
+                  "version": "1.0.0",
+                  "from": "slice-stream@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/slice-stream/-/slice-stream-1.0.0.tgz"
+                }
+              }
+            },
+            "binary": {
+              "version": "0.3.0",
+              "from": "binary@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+              "dependencies": {
+                "chainsaw": {
+                  "version": "0.1.0",
+                  "from": "chainsaw@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+                  "dependencies": {
+                    "traverse": {
+                      "version": "0.3.9",
+                      "from": "traverse@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
+                    }
+                  }
+                },
+                "buffers": {
+                  "version": "0.1.1",
+                  "from": "buffers@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "1.0.34",
+              "from": "readable-stream@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "setimmediate": {
+              "version": "1.0.4",
+              "from": "setimmediate@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz"
+            },
+            "match-stream": {
+              "version": "0.0.2",
+              "from": "match-stream@>=0.0.2 <0.1.0",
+              "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
+              "dependencies": {
+                "buffers": {
+                  "version": "0.1.1",
+                  "from": "buffers@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "node-zip": {
+          "version": "1.1.1",
+          "from": "node-zip@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/node-zip/-/node-zip-1.1.1.tgz",
+          "dependencies": {
+            "jszip": {
+              "version": "2.5.0",
+              "from": "jszip@2.5.0",
+              "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.5.0.tgz",
+              "dependencies": {
+                "pako": {
+                  "version": "0.2.9",
+                  "from": "pako@>=0.2.5 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
+                }
+              }
+            }
+          }
+        },
+        "read": {
+          "version": "1.0.7",
+          "from": "read@>=1.0.7 <2.0.0",
+          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+          "dependencies": {
+            "mute-stream": {
+              "version": "0.0.6",
+              "from": "mute-stream@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz"
+            }
+          }
+        },
         "tmp": {
           "version": "0.0.27",
-          "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.27.tgz",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.27.tgz"
+          "from": "tmp@>=0.0.27 <0.0.28",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.27.tgz",
+          "dependencies": {
+            "os-tmpdir": {
+              "version": "1.0.1",
+              "from": "os-tmpdir@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+            }
+          }
+        },
+        "underscore": {
+          "version": "1.8.3",
+          "from": "underscore@>=1.8.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
         }
       }
     },
-    "archy": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
-    },
-    "argparse": {
-      "version": "1.0.7",
-      "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz"
-    },
-    "array-differ": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
-    },
-    "array-find-index": {
-      "version": "1.0.1",
-      "from": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
-    },
-    "array-uniq": {
-      "version": "1.0.2",
-      "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
-    },
-    "asn1": {
-      "version": "0.2.3",
-      "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-    },
-    "assert-plus": {
-      "version": "0.2.0",
-      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-    },
     "async": {
       "version": "1.5.2",
-      "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "from": "async@>=1.5.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
     },
-    "aws-sign2": {
-      "version": "0.6.0",
-      "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-    },
-    "aws4": {
-      "version": "1.3.2",
-      "from": "https://registry.npmjs.org/aws4/-/aws4-1.3.2.tgz",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.3.2.tgz"
-    },
-    "backoff": {
-      "version": "2.5.0",
-      "from": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
-      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz"
-    },
-    "balanced-match": {
-      "version": "0.3.0",
-      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-    },
-    "base64-url": {
-      "version": "1.2.2",
-      "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.2.tgz",
-      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.2.tgz"
-    },
-    "base64url": {
-      "version": "1.0.6",
-      "from": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz"
-    },
-    "beeper": {
-      "version": "1.1.0",
-      "from": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
-    },
-    "binary": {
-      "version": "0.3.0",
-      "from": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz"
-    },
-    "bl": {
-      "version": "1.1.2",
-      "from": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz"
-    },
     "body-parser": {
-      "version": "1.15.0",
-      "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.0.tgz",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.0.tgz"
-    },
-    "boom": {
-      "version": "2.10.1",
-      "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-    },
-    "brace-expansion": {
-      "version": "1.1.3",
-      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz"
-    },
-    "buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "from": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
-    },
-    "buffers": {
-      "version": "0.1.1",
-      "from": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
-    },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
-    },
-    "bunyan": {
-      "version": "1.8.0",
-      "from": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.0.tgz",
-      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.0.tgz"
-    },
-    "byline": {
-      "version": "4.2.1",
-      "from": "https://registry.npmjs.org/byline/-/byline-4.2.1.tgz",
-      "resolved": "https://registry.npmjs.org/byline/-/byline-4.2.1.tgz"
-    },
-    "bytes": {
-      "version": "2.2.0",
-      "from": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
-    },
-    "camelcase": {
-      "version": "1.2.1",
-      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-    },
-    "camelcase-keys": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz"
-    },
-    "caseless": {
-      "version": "0.11.0",
-      "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-    },
-    "chainsaw": {
-      "version": "0.1.0",
-      "from": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz"
-    },
-    "chalk": {
-      "version": "1.1.3",
-      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+      "version": "1.15.2",
+      "from": "body-parser@>=1.12.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.2.tgz",
+      "dependencies": {
+        "bytes": {
+          "version": "2.4.0",
+          "from": "bytes@2.4.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
+        },
+        "content-type": {
+          "version": "1.0.2",
+          "from": "content-type@>=1.0.2 <1.1.0",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
+        },
+        "depd": {
+          "version": "1.1.0",
+          "from": "depd@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+        },
+        "http-errors": {
+          "version": "1.5.0",
+          "from": "http-errors@>=1.5.0 <1.6.0",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "setprototypeof": {
+              "version": "1.0.1",
+              "from": "setprototypeof@1.0.1",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
+            },
+            "statuses": {
+              "version": "1.3.0",
+              "from": "statuses@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
+            }
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.13",
+          "from": "iconv-lite@0.4.13",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "from": "on-finished@>=2.3.0 <2.4.0",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "dependencies": {
+            "ee-first": {
+              "version": "1.1.1",
+              "from": "ee-first@1.1.1",
+              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+            }
+          }
+        },
+        "qs": {
+          "version": "6.2.0",
+          "from": "qs@6.2.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
+        },
+        "raw-body": {
+          "version": "2.1.7",
+          "from": "raw-body@>=2.1.7 <2.2.0",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+          "dependencies": {
+            "unpipe": {
+              "version": "1.0.0",
+              "from": "unpipe@1.0.0",
+              "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+            }
+          }
+        },
+        "type-is": {
+          "version": "1.6.13",
+          "from": "type-is@>=1.6.13 <1.7.0",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+          "dependencies": {
+            "media-typer": {
+              "version": "0.3.0",
+              "from": "media-typer@0.3.0",
+              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+            },
+            "mime-types": {
+              "version": "2.1.11",
+              "from": "mime-types@>=2.1.11 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.23.0",
+                  "from": "mime-db@>=1.23.0 <1.24.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "cli-prompt": {
-      "version": "0.5.0",
-      "from": "https://registry.npmjs.org/cli-prompt/-/cli-prompt-0.5.0.tgz",
-      "resolved": "https://registry.npmjs.org/cli-prompt/-/cli-prompt-0.5.0.tgz"
-    },
-    "cli-table": {
-      "version": "0.3.1",
-      "from": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz"
-    },
-    "clone": {
-      "version": "1.0.2",
-      "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
-    },
-    "clone-stats": {
-      "version": "0.0.1",
-      "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
-    },
-    "colors": {
-      "version": "1.0.3",
-      "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
-    },
-    "combined-stream": {
-      "version": "1.0.5",
-      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+      "version": "0.5.1",
+      "from": "cli-prompt@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/cli-prompt/-/cli-prompt-0.5.1.tgz",
+      "dependencies": {
+        "keypress": {
+          "version": "0.2.1",
+          "from": "keypress@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.2.1.tgz"
+        }
+      }
     },
     "commander": {
       "version": "2.9.0",
-      "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-    },
-    "concat-stream": {
-      "version": "1.4.10",
-      "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+      "from": "commander@>=2.9.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+        "graceful-readlink": {
+          "version": "1.0.1",
+          "from": "graceful-readlink@>=1.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
         }
       }
     },
     "config": {
-      "version": "1.20.1",
-      "from": "https://registry.npmjs.org/config/-/config-1.20.1.tgz",
-      "resolved": "https://registry.npmjs.org/config/-/config-1.20.1.tgz"
-    },
-    "content-type": {
-      "version": "1.0.1",
-      "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
-    },
-    "convert-source-map": {
-      "version": "1.2.0",
-      "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz"
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+      "version": "1.21.0",
+      "from": "config@>=1.13.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/config/-/config-1.21.0.tgz",
+      "dependencies": {
+        "json5": {
+          "version": "0.4.0",
+          "from": "json5@0.4.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+        }
+      }
     },
     "cpr": {
-      "version": "1.1.1",
-      "from": "https://registry.npmjs.org/cpr/-/cpr-1.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/cpr/-/cpr-1.1.1.tgz",
+      "version": "1.1.2",
+      "from": "cpr@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/cpr/-/cpr-1.1.2.tgz",
       "dependencies": {
-        "glob": {
-          "version": "6.0.4",
-          "from": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz"
+        "graceful-fs": {
+          "version": "4.1.5",
+          "from": "graceful-fs@>=4.1.2 <4.2.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.5.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
         },
         "rimraf": {
           "version": "2.4.5",
-          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz"
+          "from": "rimraf@>=2.4.3 <2.5.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "6.0.4",
+              "from": "glob@>=6.0.1 <7.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.5",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "3.0.2",
+                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.6",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.4.2",
+                          "from": "balanced-match@>=0.4.1 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                }
+              }
+            }
+          }
         }
       }
-    },
-    "cryptiles": {
-      "version": "2.0.5",
-      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
     },
     "crypto": {
       "version": "0.0.3",
-      "from": "https://registry.npmjs.org/crypto/-/crypto-0.0.3.tgz",
+      "from": "crypto@0.0.3",
       "resolved": "https://registry.npmjs.org/crypto/-/crypto-0.0.3.tgz"
-    },
-    "csv": {
-      "version": "0.4.6",
-      "from": "https://registry.npmjs.org/csv/-/csv-0.4.6.tgz",
-      "resolved": "https://registry.npmjs.org/csv/-/csv-0.4.6.tgz"
-    },
-    "csv-generate": {
-      "version": "0.0.6",
-      "from": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.6.tgz",
-      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.6.tgz"
-    },
-    "csv-parse": {
-      "version": "1.0.4",
-      "from": "https://registry.npmjs.org/csv-parse/-/csv-parse-1.0.4.tgz",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-1.0.4.tgz"
-    },
-    "csv-stringify": {
-      "version": "0.0.8",
-      "from": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.8.tgz",
-      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.8.tgz"
-    },
-    "ctype": {
-      "version": "0.5.3",
-      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-    },
-    "cycle": {
-      "version": "1.0.3",
-      "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
-    },
-    "dashdash": {
-      "version": "1.13.0",
-      "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-        }
-      }
-    },
-    "dateformat": {
-      "version": "1.0.12",
-      "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-      "dependencies": {
-        "camelcase": {
-          "version": "2.1.1",
-          "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
-        },
-        "camelcase-keys": {
-          "version": "2.1.0",
-          "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz"
-        },
-        "meow": {
-          "version": "3.7.0",
-          "from": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
-        },
-        "object-assign": {
-          "version": "4.0.1",
-          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-        }
-      }
     },
     "debug": {
       "version": "2.2.0",
-      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-    },
-    "decamelize": {
-      "version": "1.2.0",
-      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
-    },
-    "defaults": {
-      "version": "1.0.3",
-      "from": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz"
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-    },
-    "depd": {
-      "version": "1.1.0",
-      "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
-    },
-    "deprecated": {
-      "version": "0.0.1",
-      "from": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz"
-    },
-    "diff": {
-      "version": "1.4.0",
-      "from": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
-    },
-    "dtrace-provider": {
-      "version": "0.6.0",
-      "from": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.6.0.tgz",
-      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.6.0.tgz"
-    },
-    "duplexer2": {
-      "version": "0.0.2",
-      "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+      "from": "debug@>=2.2.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         }
       }
-    },
-    "duplexify": {
-      "version": "3.4.3",
-      "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.3.tgz",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.3.tgz",
-      "dependencies": {
-        "end-of-stream": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz"
-        }
-      }
-    },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-    },
-    "ecdsa-sig-formatter": {
-      "version": "1.0.5",
-      "from": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.5.tgz",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.5.tgz"
-    },
-    "ee-first": {
-      "version": "1.1.1",
-      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
-    },
-    "end-of-stream": {
-      "version": "0.1.5",
-      "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz"
-    },
-    "error-ex": {
-      "version": "1.3.0",
-      "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
-    },
-    "escape-regexp-component": {
-      "version": "1.0.2",
-      "from": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-    },
-    "esprima": {
-      "version": "2.7.2",
-      "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
-    },
-    "extend": {
-      "version": "3.0.0",
-      "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-    },
-    "extsprintf": {
-      "version": "1.0.2",
-      "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-    },
-    "eyes": {
-      "version": "0.1.8",
-      "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
-    },
-    "fancy-log": {
-      "version": "1.2.0",
-      "from": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz"
-    },
-    "find-index": {
-      "version": "0.1.1",
-      "from": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
-    },
-    "find-up": {
-      "version": "1.1.2",
-      "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
-    },
-    "findup-sync": {
-      "version": "0.3.0",
-      "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
-      "dependencies": {
-        "glob": {
-          "version": "5.0.15",
-          "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
-        }
-      }
-    },
-    "first-chunk-stream": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
-    },
-    "flagged-respawn": {
-      "version": "0.3.2",
-      "from": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
-      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz"
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-    },
-    "form-data": {
-      "version": "1.0.0-rc4",
-      "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
-    },
-    "formidable": {
-      "version": "1.0.17",
-      "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
     },
     "fs-extra": {
       "version": "0.20.1",
-      "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.20.1.tgz",
+      "from": "fs-extra@>=0.20.1 <0.21.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.20.1.tgz",
       "dependencies": {
         "graceful-fs": {
           "version": "3.0.8",
-          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-        }
-      }
-    },
-    "fstream": {
-      "version": "0.1.31",
-      "from": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
-      "dependencies": {
-        "graceful-fs": {
-          "version": "3.0.8",
-          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-        }
-      }
-    },
-    "gaze": {
-      "version": "0.5.2",
-      "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz"
-    },
-    "generate-function": {
-      "version": "2.0.0",
-      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
-    },
-    "get-stdin": {
-      "version": "4.0.1",
-      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-    },
-    "glob": {
-      "version": "7.0.3",
-      "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz"
-    },
-    "glob-stream": {
-      "version": "3.1.18",
-      "from": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-      "dependencies": {
-        "glob": {
-          "version": "4.5.3",
-          "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-        },
-        "through2": {
-          "version": "0.6.5",
-          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
-        }
-      }
-    },
-    "glob-watcher": {
-      "version": "0.0.6",
-      "from": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-      "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz"
-    },
-    "glob2base": {
-      "version": "0.0.12",
-      "from": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-      "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz"
-    },
-    "globule": {
-      "version": "0.1.0",
-      "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-      "dependencies": {
-        "glob": {
-          "version": "3.1.21",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz"
-        },
-        "graceful-fs": {
-          "version": "1.2.3",
-          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-        },
-        "inherits": {
-          "version": "1.0.2",
-          "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
-        },
-        "lodash": {
-          "version": "1.0.2",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
-        },
-        "lru-cache": {
-          "version": "2.7.3",
-          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-        },
-        "minimatch": {
-          "version": "0.2.14",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
-        }
-      }
-    },
-    "glogg": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz"
-    },
-    "graceful-fs": {
-      "version": "4.1.3",
-      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
-    },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-    },
-    "growl": {
-      "version": "1.8.1",
-      "from": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
-    },
-    "gulp": {
-      "version": "3.9.1",
-      "from": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
-      "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz"
-    },
-    "gulp-shell": {
-      "version": "0.4.3",
-      "from": "https://registry.npmjs.org/gulp-shell/-/gulp-shell-0.4.3.tgz",
-      "resolved": "https://registry.npmjs.org/gulp-shell/-/gulp-shell-0.4.3.tgz",
-      "dependencies": {
-        "async": {
-          "version": "1.4.2",
-          "from": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
-        }
-      }
-    },
-    "gulp-sourcemaps": {
-      "version": "1.6.0",
-      "from": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-      "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-      "dependencies": {
-        "vinyl": {
-          "version": "1.1.1",
-          "from": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz"
-        }
-      }
-    },
-    "gulp-tsc": {
-      "version": "0.9.5",
-      "from": "https://registry.npmjs.org/gulp-tsc/-/gulp-tsc-0.9.5.tgz",
-      "resolved": "https://registry.npmjs.org/gulp-tsc/-/gulp-tsc-0.9.5.tgz",
-      "dependencies": {
-        "async": {
-          "version": "0.9.2",
-          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
-        },
-        "clone": {
-          "version": "0.2.0",
-          "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
-        },
-        "glob": {
-          "version": "4.5.3",
-          "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
-        },
-        "glob-stream": {
-          "version": "4.1.1",
-          "from": "https://registry.npmjs.org/glob-stream/-/glob-stream-4.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-4.1.1.tgz"
-        },
-        "glob-watcher": {
-          "version": "0.0.8",
-          "from": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.8.tgz",
-          "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.8.tgz"
-        },
-        "graceful-fs": {
-          "version": "3.0.8",
-          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+          "from": "graceful-fs@>=3.0.5 <4.0.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
         },
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
-        },
-        "object-assign": {
-          "version": "2.1.1",
-          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-        },
-        "strip-bom": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz"
-        },
-        "through2": {
-          "version": "0.6.5",
-          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
-        },
-        "unique-stream": {
-          "version": "2.2.1",
-          "from": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz"
-        },
-        "vinyl": {
-          "version": "0.4.6",
-          "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
-        },
-        "vinyl-fs": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-1.0.0.tgz"
+        "jsonfile": {
+          "version": "2.3.1",
+          "from": "jsonfile@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.1.tgz"
         }
       }
-    },
-    "gulp-util": {
-      "version": "3.0.7",
-      "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-      "dependencies": {
-        "object-assign": {
-          "version": "3.0.0",
-          "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
-        }
-      }
-    },
-    "gulplog": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz"
-    },
-    "har-validator": {
-      "version": "2.0.6",
-      "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-    },
-    "has-gulplog": {
-      "version": "0.1.0",
-      "from": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz"
-    },
-    "hawk": {
-      "version": "3.1.3",
-      "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
-    },
-    "hoek": {
-      "version": "2.16.3",
-      "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-    },
-    "hosted-git-info": {
-      "version": "2.1.4",
-      "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
-    },
-    "http-errors": {
-      "version": "1.4.0",
-      "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz"
-    },
-    "http-signature": {
-      "version": "1.1.1",
-      "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
-    },
-    "iconv-lite": {
-      "version": "0.4.13",
-      "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
-    },
-    "indent-string": {
-      "version": "1.2.2",
-      "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz"
-    },
-    "inflight": {
-      "version": "1.0.4",
-      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz"
-    },
-    "inherits": {
-      "version": "2.0.1",
-      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-    },
-    "interpret": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/interpret/-/interpret-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.0.tgz"
-    },
-    "is-absolute": {
-      "version": "0.1.7",
-      "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz"
-    },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-    },
-    "is-builtin-module": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
-    },
-    "is-finite": {
-      "version": "1.0.1",
-      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
-    },
-    "is-my-json-valid": {
-      "version": "2.13.1",
-      "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
-    },
-    "is-property": {
-      "version": "1.0.2",
-      "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-    },
-    "is-relative": {
-      "version": "0.1.3",
-      "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
-      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
-    },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-    },
-    "is-utf8": {
-      "version": "0.2.1",
-      "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-    },
-    "jade": {
-      "version": "0.26.3",
-      "from": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-      "dependencies": {
-        "commander": {
-          "version": "0.6.1",
-          "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
-        },
-        "mkdirp": {
-          "version": "0.3.0",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
-        }
-      }
-    },
-    "jodid25519": {
-      "version": "1.0.2",
-      "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
     },
     "js-yaml": {
-      "version": "3.5.5",
-      "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz"
-    },
-    "jsbn": {
-      "version": "0.1.0",
-      "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-    },
-    "json-schema": {
-      "version": "0.2.2",
-      "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
-    },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-    },
-    "json5": {
-      "version": "0.4.0",
-      "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
-    },
-    "jsonfile": {
-      "version": "2.3.1",
-      "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.1.tgz",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.1.tgz"
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-    },
-    "jsonpointer": {
-      "version": "2.0.0",
-      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+      "version": "3.6.1",
+      "from": "js-yaml@>=3.5.4 <4.0.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.7",
+          "from": "argparse@>=1.0.7 <2.0.0",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
+          "dependencies": {
+            "sprintf-js": {
+              "version": "1.0.3",
+              "from": "sprintf-js@>=1.0.2 <1.1.0",
+              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+            }
+          }
+        },
+        "esprima": {
+          "version": "2.7.2",
+          "from": "esprima@>=2.6.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+        }
+      }
     },
     "jsonwebtoken": {
       "version": "5.7.0",
-      "from": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz"
-    },
-    "jsprim": {
-      "version": "1.2.2",
-      "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
-    },
-    "jszip": {
-      "version": "2.5.0",
-      "from": "https://registry.npmjs.org/jszip/-/jszip-2.5.0.tgz",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.5.0.tgz"
-    },
-    "jwa": {
-      "version": "1.1.3",
-      "from": "https://registry.npmjs.org/jwa/-/jwa-1.1.3.tgz",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.3.tgz"
-    },
-    "jws": {
-      "version": "3.1.3",
-      "from": "https://registry.npmjs.org/jws/-/jws-3.1.3.tgz",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.3.tgz"
-    },
-    "keep-alive-agent": {
-      "version": "0.0.1",
-      "from": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
-    },
-    "keypress": {
-      "version": "0.2.1",
-      "from": "https://registry.npmjs.org/keypress/-/keypress-0.2.1.tgz",
-      "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.2.1.tgz"
-    },
-    "klaw": {
-      "version": "1.2.0",
-      "from": "https://registry.npmjs.org/klaw/-/klaw-1.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.2.0.tgz"
-    },
-    "liftoff": {
-      "version": "2.2.1",
-      "from": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.1.tgz",
-      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.1.tgz",
+      "from": "jsonwebtoken@>=5.7.0 <6.0.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz",
       "dependencies": {
-        "extend": {
-          "version": "2.0.1",
-          "from": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
+        "jws": {
+          "version": "3.1.3",
+          "from": "jws@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.3.tgz",
+          "dependencies": {
+            "base64url": {
+              "version": "1.0.6",
+              "from": "base64url@>=1.0.4 <1.1.0",
+              "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
+              "dependencies": {
+                "concat-stream": {
+                  "version": "1.4.10",
+                  "from": "concat-stream@>=1.4.7 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "from": "typedarray@>=0.0.5 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "1.1.14",
+                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "meow": {
+                  "version": "2.0.0",
+                  "from": "meow@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.2.1",
+                          "from": "camelcase@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.1",
+                          "from": "map-obj@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.2",
+                      "from": "indent-string@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                      "dependencies": {
+                        "get-stdin": {
+                          "version": "4.0.1",
+                          "from": "get-stdin@>=4.0.1 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                        },
+                        "repeating": {
+                          "version": "1.1.3",
+                          "from": "repeating@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.1",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "object-assign": {
+                      "version": "1.0.0",
+                      "from": "object-assign@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "jwa": {
+              "version": "1.1.3",
+              "from": "jwa@>=1.1.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.3.tgz",
+              "dependencies": {
+                "buffer-equal-constant-time": {
+                  "version": "1.0.1",
+                  "from": "buffer-equal-constant-time@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
+                },
+                "ecdsa-sig-formatter": {
+                  "version": "1.0.7",
+                  "from": "ecdsa-sig-formatter@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.7.tgz",
+                  "dependencies": {
+                    "base64-url": {
+                      "version": "1.3.2",
+                      "from": "base64-url@>=1.2.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.3.2.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@>=0.7.1 <0.8.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "from": "xtend@>=4.0.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
-    },
-    "load-json-file": {
-      "version": "1.1.0",
-      "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
     },
     "lodash": {
       "version": "3.10.1",
-      "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "from": "lodash@>=3.9.3 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-    },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
-    },
-    "lodash._basetostring": {
-      "version": "3.0.1",
-      "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
-    },
-    "lodash._basevalues": {
-      "version": "3.0.0",
-      "from": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
-    },
-    "lodash._reescape": {
-      "version": "3.0.0",
-      "from": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
-    },
-    "lodash._reevaluate": {
-      "version": "3.0.0",
-      "from": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
-    },
-    "lodash._reinterpolate": {
-      "version": "3.0.0",
-      "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
-    },
-    "lodash._root": {
-      "version": "3.0.1",
-      "from": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
-    },
-    "lodash.escape": {
-      "version": "3.2.0",
-      "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz"
-    },
-    "lodash.isarguments": {
-      "version": "3.0.8",
-      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
-    },
-    "lodash.restparam": {
-      "version": "3.6.1",
-      "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
-    },
-    "lodash.template": {
-      "version": "3.6.2",
-      "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz"
-    },
-    "lodash.templatesettings": {
-      "version": "3.1.1",
-      "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
     },
     "log-symbols": {
       "version": "1.0.2",
-      "from": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz"
-    },
-    "loud-rejection": {
-      "version": "1.3.0",
-      "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz"
-    },
-    "lru-cache": {
-      "version": "4.0.1",
-      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz"
-    },
-    "lru-cache-plus": {
-      "version": "2.5.0",
-      "from": "https://registry.npmjs.org/lru-cache-plus/-/lru-cache-plus-2.5.0.tgz",
-      "resolved": "https://registry.npmjs.org/lru-cache-plus/-/lru-cache-plus-2.5.0.tgz"
-    },
-    "map-obj": {
-      "version": "1.0.1",
-      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-    },
-    "match-stream": {
-      "version": "0.0.2",
-      "from": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
+      "from": "log-symbols@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-        }
-      }
-    },
-    "media-typer": {
-      "version": "0.3.0",
-      "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
-    },
-    "meow": {
-      "version": "2.0.0",
-      "from": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz"
-    },
-    "merge-stream": {
-      "version": "0.1.8",
-      "from": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.8.tgz",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.8.tgz",
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-        },
-        "through2": {
-          "version": "0.6.5",
-          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
+        "chalk": {
+          "version": "1.1.3",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "from": "ansi-styles@>=2.2.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
         }
       }
     },
     "microgateway-config": {
       "version": "2.0.9",
-      "from": "microgateway-config@2.0.9",
+      "from": "microgateway-config@>=2.0.9 <3.0.0",
+      "resolved": "https://registry.npmjs.org/microgateway-config/-/microgateway-config-2.0.9.tgz",
       "dependencies": {
         "fs-extra": {
           "version": "0.26.7",
-          "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz"
+          "from": "fs-extra@>=0.26.6 <0.27.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "4.1.5",
+              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.5.tgz"
+            },
+            "jsonfile": {
+              "version": "2.3.1",
+              "from": "jsonfile@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.1.tgz"
+            },
+            "klaw": {
+              "version": "1.3.0",
+              "from": "klaw@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz"
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+            }
+          }
         },
         "lodash": {
-          "version": "4.12.0",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-4.12.0.tgz",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.12.0.tgz"
+          "version": "4.14.0",
+          "from": "lodash@>=4.6.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.0.tgz"
         }
       }
     },
     "microgateway-core": {
-      "version": "2.0.15",
-      "from": "microgateway-core@>=2.0.14 <3.0.0",
+      "version": "2.0.16-pcf.0",
+      "from": "apigee/microgateway-core#pcf",
+      "resolved": "git://github.com/apigee/microgateway-core.git#41debc5473570cef99db2678d52d48b01f92c93f",
       "dependencies": {
-        "bl": {
-          "version": "1.0.3",
-          "from": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz"
-        },
         "lodash": {
           "version": "3.9.3",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
+          "from": "lodash@>=3.9.3 <3.10.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
         },
-        "qs": {
-          "version": "6.0.2",
-          "from": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
         },
         "request": {
           "version": "2.69.0",
-          "from": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz"
+          "from": "request@>=2.69.0 <2.70.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.6.0",
+              "from": "aws-sign2@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+            },
+            "aws4": {
+              "version": "1.4.1",
+              "from": "aws4@>=1.2.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
+            },
+            "bl": {
+              "version": "1.0.3",
+              "from": "bl@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "from": "readable-stream@>=2.0.5 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.11.0",
+              "from": "caseless@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "from": "combined-stream@>=1.0.5 <1.1.0",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "from": "delayed-stream@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.0",
+              "from": "extend@>=3.0.0 <3.1.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "from": "forever-agent@>=0.6.1 <0.7.0",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+            },
+            "form-data": {
+              "version": "1.0.0-rc4",
+              "from": "form-data@>=1.0.0-rc3 <1.1.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
+            },
+            "har-validator": {
+              "version": "2.0.6",
+              "from": "har-validator@>=2.0.6 <2.1.0",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "1.1.3",
+                  "from": "chalk@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "from": "ansi-styles@>=2.2.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "has-ansi@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "from": "supports-color@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    }
+                  }
+                },
+                "is-my-json-valid": {
+                  "version": "2.13.1",
+                  "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+                  "dependencies": {
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "from": "generate-function@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "dependencies": {
+                        "is-property": {
+                          "version": "1.0.2",
+                          "from": "is-property@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "jsonpointer": {
+                      "version": "2.0.0",
+                      "from": "jsonpointer@2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    }
+                  }
+                },
+                "pinkie-promise": {
+                  "version": "2.0.1",
+                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                  "dependencies": {
+                    "pinkie": {
+                      "version": "2.0.4",
+                      "from": "pinkie@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "from": "hawk@>=3.1.0 <3.2.0",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "2.16.3",
+                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                },
+                "boom": {
+                  "version": "2.10.1",
+                  "from": "boom@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "from": "http-signature@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.2.0",
+                  "from": "assert-plus@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                },
+                "jsprim": {
+                  "version": "1.3.0",
+                  "from": "jsprim@>=1.2.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
+                  "dependencies": {
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "from": "extsprintf@1.0.2",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                    },
+                    "json-schema": {
+                      "version": "0.2.2",
+                      "from": "json-schema@0.2.2",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "from": "verror@1.3.6",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.9.1",
+                  "from": "sshpk@>=1.7.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.9.1.tgz",
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.2.3",
+                      "from": "asn1@>=0.2.3 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                    },
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "assert-plus@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                    },
+                    "dashdash": {
+                      "version": "1.14.0",
+                      "from": "dashdash@>=1.12.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz"
+                    },
+                    "getpass": {
+                      "version": "0.1.6",
+                      "from": "getpass@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
+                    },
+                    "jsbn": {
+                      "version": "0.1.0",
+                      "from": "jsbn@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                    },
+                    "tweetnacl": {
+                      "version": "0.13.3",
+                      "from": "tweetnacl@>=0.13.0 <0.14.0",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "from": "jodid25519@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "from": "is-typedarray@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "isstream@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+            },
+            "mime-types": {
+              "version": "2.1.11",
+              "from": "mime-types@>=2.1.7 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.23.0",
+                  "from": "mime-db@>=1.23.0 <1.24.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.7",
+              "from": "node-uuid@>=1.4.7 <1.5.0",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "from": "oauth-sign@>=0.8.0 <0.9.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+            },
+            "qs": {
+              "version": "6.0.2",
+              "from": "qs@>=6.0.2 <6.1.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "from": "stringstream@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+            },
+            "tough-cookie": {
+              "version": "2.2.2",
+              "from": "tough-cookie@>=2.2.0 <2.3.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.3",
+              "from": "tunnel-agent@>=0.4.1 <0.5.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+            }
+          }
+        },
+        "winston": {
+          "version": "2.2.0",
+          "from": "winston@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/winston/-/winston-2.2.0.tgz",
+          "dependencies": {
+            "async": {
+              "version": "1.0.0",
+              "from": "async@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz"
+            },
+            "colors": {
+              "version": "1.0.3",
+              "from": "colors@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+            },
+            "cycle": {
+              "version": "1.0.3",
+              "from": "cycle@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
+            },
+            "eyes": {
+              "version": "0.1.8",
+              "from": "eyes@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "isstream@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            },
+            "pkginfo": {
+              "version": "0.3.1",
+              "from": "pkginfo@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
+            },
+            "stack-trace": {
+              "version": "0.0.9",
+              "from": "stack-trace@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
+            }
+          }
+        },
+        "winston-daily-rotate-file": {
+          "version": "1.0.1",
+          "from": "winston-daily-rotate-file@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-1.0.1.tgz",
+          "dependencies": {
+            "winston": {
+              "version": "2.1.1",
+              "from": "winston@>=2.1.0 <2.2.0",
+              "resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "1.0.0",
+                  "from": "async@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz"
+                },
+                "colors": {
+                  "version": "1.0.3",
+                  "from": "colors@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+                },
+                "cycle": {
+                  "version": "1.0.3",
+                  "from": "cycle@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
+                },
+                "eyes": {
+                  "version": "0.1.8",
+                  "from": "eyes@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "isstream@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                },
+                "pkginfo": {
+                  "version": "0.3.1",
+                  "from": "pkginfo@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
+                },
+                "stack-trace": {
+                  "version": "0.0.9",
+                  "from": "stack-trace@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
+                }
+              }
+            }
+          }
         }
       }
     },
     "microgateway-edgeauth": {
       "version": "1.0.2",
-      "from": "microgateway-edgeauth@1.0.2",
+      "from": "microgateway-edgeauth@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/microgateway-edgeauth/-/microgateway-edgeauth-1.0.2.tgz",
       "dependencies": {
         "a127-magic": {
           "version": "0.12.1",
-          "from": "https://registry.npmjs.org/a127-magic/-/a127-magic-0.12.1.tgz",
-          "resolved": "https://registry.npmjs.org/a127-magic/-/a127-magic-0.12.1.tgz"
-        },
-        "accepts": {
-          "version": "1.2.13",
-          "from": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz"
-        },
-        "append-field": {
-          "version": "0.1.0",
-          "from": "https://registry.npmjs.org/append-field/-/append-field-0.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/append-field/-/append-field-0.1.0.tgz"
-        },
-        "array-flatten": {
-          "version": "1.1.1",
-          "from": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
-        },
-        "bl": {
-          "version": "1.0.3",
-          "from": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
+          "from": "a127-magic@>=0.12.1 <0.13.0",
+          "resolved": "https://registry.npmjs.org/a127-magic/-/a127-magic-0.12.1.tgz",
           "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+            "cors": {
+              "version": "2.7.1",
+              "from": "cors@>=2.5.3 <3.0.0",
+              "resolved": "https://registry.npmjs.org/cors/-/cors-2.7.1.tgz",
+              "dependencies": {
+                "vary": {
+                  "version": "1.1.0",
+                  "from": "vary@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
+                }
+              }
             },
-            "readable-stream": {
-              "version": "2.0.6",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+            "lodash": {
+              "version": "4.14.0",
+              "from": "lodash@>=4.5.1 <5.0.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.0.tgz"
+            },
+            "splitargs": {
+              "version": "0.0.3",
+              "from": "splitargs@0.0.3",
+              "resolved": "https://registry.npmjs.org/splitargs/-/splitargs-0.0.3.tgz"
+            },
+            "swagger-docs": {
+              "version": "0.0.0-alpha2",
+              "from": "swagger-docs@0.0.0-alpha2",
+              "resolved": "https://registry.npmjs.org/swagger-docs/-/swagger-docs-0.0.0-alpha2.tgz",
+              "dependencies": {
+                "serve-static": {
+                  "version": "1.11.1",
+                  "from": "serve-static@>=1.9.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
+                  "dependencies": {
+                    "encodeurl": {
+                      "version": "1.0.1",
+                      "from": "encodeurl@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
+                    },
+                    "escape-html": {
+                      "version": "1.0.3",
+                      "from": "escape-html@>=1.0.3 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+                    },
+                    "parseurl": {
+                      "version": "1.3.1",
+                      "from": "parseurl@>=1.3.1 <1.4.0",
+                      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+                    },
+                    "send": {
+                      "version": "0.14.1",
+                      "from": "send@0.14.1",
+                      "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
+                      "dependencies": {
+                        "depd": {
+                          "version": "1.1.0",
+                          "from": "depd@>=1.1.0 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+                        },
+                        "destroy": {
+                          "version": "1.0.4",
+                          "from": "destroy@>=1.0.4 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+                        },
+                        "etag": {
+                          "version": "1.7.0",
+                          "from": "etag@>=1.7.0 <1.8.0",
+                          "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
+                        },
+                        "fresh": {
+                          "version": "0.3.0",
+                          "from": "fresh@0.3.0",
+                          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
+                        },
+                        "http-errors": {
+                          "version": "1.5.0",
+                          "from": "http-errors@>=1.5.0 <1.6.0",
+                          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
+                          "dependencies": {
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "setprototypeof": {
+                              "version": "1.0.1",
+                              "from": "setprototypeof@1.0.1",
+                              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "mime": {
+                          "version": "1.3.4",
+                          "from": "mime@1.3.4",
+                          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+                        },
+                        "ms": {
+                          "version": "0.7.1",
+                          "from": "ms@0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        },
+                        "on-finished": {
+                          "version": "2.3.0",
+                          "from": "on-finished@>=2.3.0 <2.4.0",
+                          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                          "dependencies": {
+                            "ee-first": {
+                              "version": "1.1.1",
+                              "from": "ee-first@1.1.1",
+                              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+                            }
+                          }
+                        },
+                        "range-parser": {
+                          "version": "1.2.0",
+                          "from": "range-parser@>=1.2.0 <1.3.0",
+                          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
+                        },
+                        "statuses": {
+                          "version": "1.3.0",
+                          "from": "statuses@>=1.3.0 <1.4.0",
+                          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "swagger-tools": {
+              "version": "0.10.1",
+              "from": "swagger-tools@>=0.10.1 <0.11.0",
+              "resolved": "https://registry.npmjs.org/swagger-tools/-/swagger-tools-0.10.1.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "1.5.2",
+                  "from": "async@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+                },
+                "body-parser": {
+                  "version": "1.12.4",
+                  "from": "body-parser@1.12.4",
+                  "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.4.tgz",
+                  "dependencies": {
+                    "bytes": {
+                      "version": "1.0.0",
+                      "from": "bytes@1.0.0",
+                      "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
+                    },
+                    "content-type": {
+                      "version": "1.0.2",
+                      "from": "content-type@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
+                    },
+                    "depd": {
+                      "version": "1.0.1",
+                      "from": "depd@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
+                    },
+                    "iconv-lite": {
+                      "version": "0.4.8",
+                      "from": "iconv-lite@0.4.8",
+                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz"
+                    },
+                    "on-finished": {
+                      "version": "2.2.1",
+                      "from": "on-finished@>=2.2.1 <2.3.0",
+                      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
+                      "dependencies": {
+                        "ee-first": {
+                          "version": "1.1.0",
+                          "from": "ee-first@1.1.0",
+                          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
+                        }
+                      }
+                    },
+                    "qs": {
+                      "version": "2.4.2",
+                      "from": "qs@2.4.2",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
+                    },
+                    "raw-body": {
+                      "version": "2.0.2",
+                      "from": "raw-body@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.0.2.tgz",
+                      "dependencies": {
+                        "bytes": {
+                          "version": "2.1.0",
+                          "from": "bytes@2.1.0",
+                          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz"
+                        }
+                      }
+                    },
+                    "type-is": {
+                      "version": "1.6.13",
+                      "from": "type-is@>=1.6.2 <1.7.0",
+                      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+                      "dependencies": {
+                        "media-typer": {
+                          "version": "0.3.0",
+                          "from": "media-typer@0.3.0",
+                          "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+                        },
+                        "mime-types": {
+                          "version": "2.1.11",
+                          "from": "mime-types@>=2.1.11 <2.2.0",
+                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                          "dependencies": {
+                            "mime-db": {
+                              "version": "1.23.0",
+                              "from": "mime-db@>=1.23.0 <1.24.0",
+                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "commander": {
+                  "version": "2.9.0",
+                  "from": "commander@>=2.8.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "graceful-readlink@>=1.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                    }
+                  }
+                },
+                "json-refs": {
+                  "version": "2.1.6",
+                  "from": "json-refs@>=2.1.5 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/json-refs/-/json-refs-2.1.6.tgz",
+                  "dependencies": {
+                    "native-promise-only": {
+                      "version": "0.8.1",
+                      "from": "native-promise-only@>=0.8.1 <0.9.0",
+                      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz"
+                    },
+                    "path-loader": {
+                      "version": "1.0.1",
+                      "from": "path-loader@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-loader/-/path-loader-1.0.1.tgz"
+                    },
+                    "slash": {
+                      "version": "1.0.0",
+                      "from": "slash@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+                    },
+                    "uri-js": {
+                      "version": "2.1.1",
+                      "from": "uri-js@>=2.1.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-2.1.1.tgz"
+                    }
+                  }
+                },
+                "lodash-compat": {
+                  "version": "3.10.2",
+                  "from": "lodash-compat@>=3.10.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash-compat/-/lodash-compat-3.10.2.tgz"
+                },
+                "multer": {
+                  "version": "1.1.0",
+                  "from": "multer@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/multer/-/multer-1.1.0.tgz",
+                  "dependencies": {
+                    "append-field": {
+                      "version": "0.1.0",
+                      "from": "append-field@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/append-field/-/append-field-0.1.0.tgz"
+                    },
+                    "busboy": {
+                      "version": "0.2.13",
+                      "from": "busboy@>=0.2.11 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.13.tgz",
+                      "dependencies": {
+                        "dicer": {
+                          "version": "0.2.5",
+                          "from": "dicer@0.2.5",
+                          "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
+                          "dependencies": {
+                            "streamsearch": {
+                              "version": "0.1.2",
+                              "from": "streamsearch@0.1.2",
+                              "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz"
+                            }
+                          }
+                        },
+                        "readable-stream": {
+                          "version": "1.1.14",
+                          "from": "readable-stream@>=1.1.0 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "concat-stream": {
+                      "version": "1.5.1",
+                      "from": "concat-stream@>=1.5.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "from": "typedarray@>=0.0.5 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                        },
+                        "readable-stream": {
+                          "version": "2.0.6",
+                          "from": "readable-stream@>=2.0.0 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                            },
+                            "isarray": {
+                              "version": "1.0.0",
+                              "from": "isarray@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.7",
+                              "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2",
+                              "from": "util-deprecate@>=1.0.1 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "mkdirp@>=0.5.1 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "from": "minimist@0.0.8",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                        }
+                      }
+                    },
+                    "object-assign": {
+                      "version": "3.0.0",
+                      "from": "object-assign@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                    },
+                    "on-finished": {
+                      "version": "2.3.0",
+                      "from": "on-finished@>=2.3.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                      "dependencies": {
+                        "ee-first": {
+                          "version": "1.1.1",
+                          "from": "ee-first@1.1.1",
+                          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+                        }
+                      }
+                    },
+                    "type-is": {
+                      "version": "1.6.13",
+                      "from": "type-is@>=1.6.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+                      "dependencies": {
+                        "media-typer": {
+                          "version": "0.3.0",
+                          "from": "media-typer@0.3.0",
+                          "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+                        },
+                        "mime-types": {
+                          "version": "2.1.11",
+                          "from": "mime-types@>=2.1.11 <2.2.0",
+                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                          "dependencies": {
+                            "mime-db": {
+                              "version": "1.23.0",
+                              "from": "mime-db@>=1.23.0 <1.24.0",
+                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    }
+                  }
+                },
+                "parseurl": {
+                  "version": "1.3.1",
+                  "from": "parseurl@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+                },
+                "path-to-regexp": {
+                  "version": "1.5.3",
+                  "from": "path-to-regexp@>=1.2.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.5.3.tgz",
+                  "dependencies": {
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    }
+                  }
+                },
+                "qs": {
+                  "version": "4.0.0",
+                  "from": "qs@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
+                },
+                "serve-static": {
+                  "version": "1.11.1",
+                  "from": "serve-static@>=1.10.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
+                  "dependencies": {
+                    "encodeurl": {
+                      "version": "1.0.1",
+                      "from": "encodeurl@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
+                    },
+                    "escape-html": {
+                      "version": "1.0.3",
+                      "from": "escape-html@>=1.0.3 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+                    },
+                    "send": {
+                      "version": "0.14.1",
+                      "from": "send@0.14.1",
+                      "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
+                      "dependencies": {
+                        "depd": {
+                          "version": "1.1.0",
+                          "from": "depd@>=1.1.0 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+                        },
+                        "destroy": {
+                          "version": "1.0.4",
+                          "from": "destroy@>=1.0.4 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+                        },
+                        "etag": {
+                          "version": "1.7.0",
+                          "from": "etag@>=1.7.0 <1.8.0",
+                          "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
+                        },
+                        "fresh": {
+                          "version": "0.3.0",
+                          "from": "fresh@0.3.0",
+                          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
+                        },
+                        "http-errors": {
+                          "version": "1.5.0",
+                          "from": "http-errors@>=1.5.0 <1.6.0",
+                          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
+                          "dependencies": {
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "setprototypeof": {
+                              "version": "1.0.1",
+                              "from": "setprototypeof@1.0.1",
+                              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "mime": {
+                          "version": "1.3.4",
+                          "from": "mime@1.3.4",
+                          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+                        },
+                        "ms": {
+                          "version": "0.7.1",
+                          "from": "ms@0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        },
+                        "on-finished": {
+                          "version": "2.3.0",
+                          "from": "on-finished@>=2.3.0 <2.4.0",
+                          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                          "dependencies": {
+                            "ee-first": {
+                              "version": "1.1.1",
+                              "from": "ee-first@1.1.1",
+                              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+                            }
+                          }
+                        },
+                        "range-parser": {
+                          "version": "1.2.0",
+                          "from": "range-parser@>=1.2.0 <1.3.0",
+                          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
+                        },
+                        "statuses": {
+                          "version": "1.3.0",
+                          "from": "statuses@>=1.3.0 <1.4.0",
+                          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "spark-md5": {
+                  "version": "1.0.1",
+                  "from": "spark-md5@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-1.0.1.tgz"
+                },
+                "string": {
+                  "version": "3.3.1",
+                  "from": "string@>=3.3.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/string/-/string-3.3.1.tgz"
+                },
+                "superagent": {
+                  "version": "1.8.3",
+                  "from": "superagent@>=1.2.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.8.3.tgz",
+                  "dependencies": {
+                    "qs": {
+                      "version": "2.3.3",
+                      "from": "qs@2.3.3",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                    },
+                    "formidable": {
+                      "version": "1.0.17",
+                      "from": "formidable@>=1.0.14 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
+                    },
+                    "mime": {
+                      "version": "1.3.4",
+                      "from": "mime@1.3.4",
+                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+                    },
+                    "component-emitter": {
+                      "version": "1.2.1",
+                      "from": "component-emitter@>=1.2.0 <1.3.0",
+                      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz"
+                    },
+                    "methods": {
+                      "version": "1.1.2",
+                      "from": "methods@>=1.1.1 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
+                    },
+                    "cookiejar": {
+                      "version": "2.0.6",
+                      "from": "cookiejar@2.0.6",
+                      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz"
+                    },
+                    "reduce-component": {
+                      "version": "1.0.1",
+                      "from": "reduce-component@1.0.1",
+                      "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz"
+                    },
+                    "extend": {
+                      "version": "3.0.0",
+                      "from": "extend@3.0.0",
+                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                    },
+                    "form-data": {
+                      "version": "1.0.0-rc3",
+                      "from": "form-data@1.0.0-rc3",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+                      "dependencies": {
+                        "combined-stream": {
+                          "version": "1.0.5",
+                          "from": "combined-stream@>=1.0.5 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                          "dependencies": {
+                            "delayed-stream": {
+                              "version": "1.0.0",
+                              "from": "delayed-stream@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "mime-types": {
+                          "version": "2.1.11",
+                          "from": "mime-types@>=2.1.3 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                          "dependencies": {
+                            "mime-db": {
+                              "version": "1.23.0",
+                              "from": "mime-db@>=1.23.0 <1.24.0",
+                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "1.0.27-1",
+                      "from": "readable-stream@1.0.27-1",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "swagger-converter": {
+                  "version": "0.1.7",
+                  "from": "swagger-converter@>=0.1.7 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/swagger-converter/-/swagger-converter-0.1.7.tgz",
+                  "dependencies": {
+                    "lodash.clonedeep": {
+                      "version": "2.4.1",
+                      "from": "lodash.clonedeep@>=2.4.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._baseclone": {
+                          "version": "2.4.1",
+                          "from": "lodash._baseclone@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash.assign": {
+                              "version": "2.4.1",
+                              "from": "lodash.assign@>=2.4.1 <2.5.0",
+                              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz",
+                              "dependencies": {
+                                "lodash.keys": {
+                                  "version": "2.4.1",
+                                  "from": "lodash.keys@>=2.4.1 <2.5.0",
+                                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                                  "dependencies": {
+                                    "lodash._isnative": {
+                                      "version": "2.4.1",
+                                      "from": "lodash._isnative@>=2.4.1 <2.5.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                                    },
+                                    "lodash._shimkeys": {
+                                      "version": "2.4.1",
+                                      "from": "lodash._shimkeys@>=2.4.1 <2.5.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
+                                    }
+                                  }
+                                },
+                                "lodash._objecttypes": {
+                                  "version": "2.4.1",
+                                  "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                                  "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                                }
+                              }
+                            },
+                            "lodash.foreach": {
+                              "version": "2.4.1",
+                              "from": "lodash.foreach@>=2.4.1 <2.5.0",
+                              "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-2.4.1.tgz"
+                            },
+                            "lodash.forown": {
+                              "version": "2.4.1",
+                              "from": "lodash.forown@>=2.4.1 <2.5.0",
+                              "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.4.1.tgz",
+                              "dependencies": {
+                                "lodash.keys": {
+                                  "version": "2.4.1",
+                                  "from": "lodash.keys@>=2.4.1 <2.5.0",
+                                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                                  "dependencies": {
+                                    "lodash._isnative": {
+                                      "version": "2.4.1",
+                                      "from": "lodash._isnative@>=2.4.1 <2.5.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                                    },
+                                    "lodash._shimkeys": {
+                                      "version": "2.4.1",
+                                      "from": "lodash._shimkeys@>=2.4.1 <2.5.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
+                                    }
+                                  }
+                                },
+                                "lodash._objecttypes": {
+                                  "version": "2.4.1",
+                                  "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                                  "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                                }
+                              }
+                            },
+                            "lodash._getarray": {
+                              "version": "2.4.1",
+                              "from": "lodash._getarray@>=2.4.1 <2.5.0",
+                              "resolved": "https://registry.npmjs.org/lodash._getarray/-/lodash._getarray-2.4.1.tgz",
+                              "dependencies": {
+                                "lodash._arraypool": {
+                                  "version": "2.4.1",
+                                  "from": "lodash._arraypool@>=2.4.1 <2.5.0",
+                                  "resolved": "https://registry.npmjs.org/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz"
+                                }
+                              }
+                            },
+                            "lodash.isarray": {
+                              "version": "2.4.1",
+                              "from": "lodash.isarray@>=2.4.1 <2.5.0",
+                              "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-2.4.1.tgz",
+                              "dependencies": {
+                                "lodash._isnative": {
+                                  "version": "2.4.1",
+                                  "from": "lodash._isnative@>=2.4.1 <2.5.0",
+                                  "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                                }
+                              }
+                            },
+                            "lodash.isobject": {
+                              "version": "2.4.1",
+                              "from": "lodash.isobject@>=2.4.1 <2.5.0",
+                              "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                              "dependencies": {
+                                "lodash._objecttypes": {
+                                  "version": "2.4.1",
+                                  "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                                  "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                                }
+                              }
+                            },
+                            "lodash._releasearray": {
+                              "version": "2.4.1",
+                              "from": "lodash._releasearray@>=2.4.1 <2.5.0",
+                              "resolved": "https://registry.npmjs.org/lodash._releasearray/-/lodash._releasearray-2.4.1.tgz",
+                              "dependencies": {
+                                "lodash._arraypool": {
+                                  "version": "2.4.1",
+                                  "from": "lodash._arraypool@>=2.4.1 <2.5.0",
+                                  "resolved": "https://registry.npmjs.org/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz"
+                                },
+                                "lodash._maxpoolsize": {
+                                  "version": "2.4.1",
+                                  "from": "lodash._maxpoolsize@>=2.4.1 <2.5.0",
+                                  "resolved": "https://registry.npmjs.org/lodash._maxpoolsize/-/lodash._maxpoolsize-2.4.1.tgz"
+                                }
+                              }
+                            },
+                            "lodash._slice": {
+                              "version": "2.4.1",
+                              "from": "lodash._slice@>=2.4.1 <2.5.0",
+                              "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz"
+                            }
+                          }
+                        },
+                        "lodash._basecreatecallback": {
+                          "version": "2.4.1",
+                          "from": "lodash._basecreatecallback@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash.bind": {
+                              "version": "2.4.1",
+                              "from": "lodash.bind@>=2.4.1 <2.5.0",
+                              "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
+                              "dependencies": {
+                                "lodash._createwrapper": {
+                                  "version": "2.4.1",
+                                  "from": "lodash._createwrapper@>=2.4.1 <2.5.0",
+                                  "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
+                                  "dependencies": {
+                                    "lodash._basebind": {
+                                      "version": "2.4.1",
+                                      "from": "lodash._basebind@>=2.4.1 <2.5.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
+                                      "dependencies": {
+                                        "lodash._basecreate": {
+                                          "version": "2.4.1",
+                                          "from": "lodash._basecreate@>=2.4.1 <2.5.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                                          "dependencies": {
+                                            "lodash._isnative": {
+                                              "version": "2.4.1",
+                                              "from": "lodash._isnative@>=2.4.1 <2.5.0",
+                                              "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                                            },
+                                            "lodash.noop": {
+                                              "version": "2.4.1",
+                                              "from": "lodash.noop@>=2.4.1 <2.5.0",
+                                              "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
+                                            }
+                                          }
+                                        },
+                                        "lodash.isobject": {
+                                          "version": "2.4.1",
+                                          "from": "lodash.isobject@>=2.4.1 <2.5.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                                          "dependencies": {
+                                            "lodash._objecttypes": {
+                                              "version": "2.4.1",
+                                              "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                                              "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "lodash._basecreatewrapper": {
+                                      "version": "2.4.1",
+                                      "from": "lodash._basecreatewrapper@>=2.4.1 <2.5.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
+                                      "dependencies": {
+                                        "lodash._basecreate": {
+                                          "version": "2.4.1",
+                                          "from": "lodash._basecreate@>=2.4.1 <2.5.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                                          "dependencies": {
+                                            "lodash._isnative": {
+                                              "version": "2.4.1",
+                                              "from": "lodash._isnative@>=2.4.1 <2.5.0",
+                                              "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                                            },
+                                            "lodash.noop": {
+                                              "version": "2.4.1",
+                                              "from": "lodash.noop@>=2.4.1 <2.5.0",
+                                              "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
+                                            }
+                                          }
+                                        },
+                                        "lodash.isobject": {
+                                          "version": "2.4.1",
+                                          "from": "lodash.isobject@>=2.4.1 <2.5.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                                          "dependencies": {
+                                            "lodash._objecttypes": {
+                                              "version": "2.4.1",
+                                              "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                                              "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "lodash.isfunction": {
+                                      "version": "2.4.1",
+                                      "from": "lodash.isfunction@>=2.4.1 <2.5.0",
+                                      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
+                                    }
+                                  }
+                                },
+                                "lodash._slice": {
+                                  "version": "2.4.1",
+                                  "from": "lodash._slice@>=2.4.1 <2.5.0",
+                                  "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz"
+                                }
+                              }
+                            },
+                            "lodash.identity": {
+                              "version": "2.4.1",
+                              "from": "lodash.identity@>=2.4.1 <2.5.0",
+                              "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz"
+                            },
+                            "lodash._setbinddata": {
+                              "version": "2.4.1",
+                              "from": "lodash._setbinddata@>=2.4.1 <2.5.0",
+                              "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
+                              "dependencies": {
+                                "lodash._isnative": {
+                                  "version": "2.4.1",
+                                  "from": "lodash._isnative@>=2.4.1 <2.5.0",
+                                  "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                                },
+                                "lodash.noop": {
+                                  "version": "2.4.1",
+                                  "from": "lodash.noop@>=2.4.1 <2.5.0",
+                                  "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
+                                }
+                              }
+                            },
+                            "lodash.support": {
+                              "version": "2.4.1",
+                              "from": "lodash.support@>=2.4.1 <2.5.0",
+                              "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
+                              "dependencies": {
+                                "lodash._isnative": {
+                                  "version": "2.4.1",
+                                  "from": "lodash._isnative@>=2.4.1 <2.5.0",
+                                  "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "traverse": {
+                  "version": "0.6.6",
+                  "from": "traverse@>=0.6.6 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
+                },
+                "z-schema": {
+                  "version": "3.17.0",
+                  "from": "z-schema@>=3.15.4 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.17.0.tgz",
+                  "dependencies": {
+                    "lodash.get": {
+                      "version": "4.4.0",
+                      "from": "lodash.get@>=4.1.2 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.0.tgz"
+                    },
+                    "validator": {
+                      "version": "5.5.0",
+                      "from": "validator@>=5.0.0 <6.0.0",
+                      "resolved": "https://registry.npmjs.org/validator/-/validator-5.5.0.tgz"
+                    },
+                    "request": {
+                      "version": "2.74.0",
+                      "from": "request@>=2.54.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+                      "dependencies": {
+                        "aws-sign2": {
+                          "version": "0.6.0",
+                          "from": "aws-sign2@>=0.6.0 <0.7.0",
+                          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                        },
+                        "aws4": {
+                          "version": "1.4.1",
+                          "from": "aws4@>=1.2.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
+                        },
+                        "bl": {
+                          "version": "1.1.2",
+                          "from": "bl@>=1.1.2 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+                          "dependencies": {
+                            "readable-stream": {
+                              "version": "2.0.6",
+                              "from": "readable-stream@>=2.0.5 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.2",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "1.0.0",
+                                  "from": "isarray@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                                },
+                                "process-nextick-args": {
+                                  "version": "1.0.7",
+                                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "util-deprecate": {
+                                  "version": "1.0.2",
+                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "caseless": {
+                          "version": "0.11.0",
+                          "from": "caseless@>=0.11.0 <0.12.0",
+                          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                        },
+                        "combined-stream": {
+                          "version": "1.0.5",
+                          "from": "combined-stream@>=1.0.5 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                          "dependencies": {
+                            "delayed-stream": {
+                              "version": "1.0.0",
+                              "from": "delayed-stream@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "extend": {
+                          "version": "3.0.0",
+                          "from": "extend@>=3.0.0 <3.1.0",
+                          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                        },
+                        "forever-agent": {
+                          "version": "0.6.1",
+                          "from": "forever-agent@>=0.6.1 <0.7.0",
+                          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                        },
+                        "form-data": {
+                          "version": "1.0.0-rc4",
+                          "from": "form-data@>=1.0.0-rc4 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
+                        },
+                        "har-validator": {
+                          "version": "2.0.6",
+                          "from": "har-validator@>=2.0.6 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.1.3",
+                              "from": "chalk@>=1.1.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.2.1",
+                                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.5",
+                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "2.0.0",
+                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "3.0.1",
+                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "2.0.0",
+                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "is-my-json-valid": {
+                              "version": "2.13.1",
+                              "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+                              "dependencies": {
+                                "generate-function": {
+                                  "version": "2.0.0",
+                                  "from": "generate-function@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                                },
+                                "generate-object-property": {
+                                  "version": "1.2.0",
+                                  "from": "generate-object-property@>=1.1.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                                  "dependencies": {
+                                    "is-property": {
+                                      "version": "1.0.2",
+                                      "from": "is-property@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "jsonpointer": {
+                                  "version": "2.0.0",
+                                  "from": "jsonpointer@2.0.0",
+                                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                                },
+                                "xtend": {
+                                  "version": "4.0.1",
+                                  "from": "xtend@>=4.0.0 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                                }
+                              }
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.1",
+                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.4",
+                                  "from": "pinkie@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "hawk": {
+                          "version": "3.1.3",
+                          "from": "hawk@>=3.1.3 <3.2.0",
+                          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                          "dependencies": {
+                            "hoek": {
+                              "version": "2.16.3",
+                              "from": "hoek@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                            },
+                            "boom": {
+                              "version": "2.10.1",
+                              "from": "boom@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                            },
+                            "cryptiles": {
+                              "version": "2.0.5",
+                              "from": "cryptiles@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                            },
+                            "sntp": {
+                              "version": "1.0.9",
+                              "from": "sntp@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                            }
+                          }
+                        },
+                        "http-signature": {
+                          "version": "1.1.1",
+                          "from": "http-signature@>=1.1.0 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                          "dependencies": {
+                            "assert-plus": {
+                              "version": "0.2.0",
+                              "from": "assert-plus@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                            },
+                            "jsprim": {
+                              "version": "1.3.0",
+                              "from": "jsprim@>=1.2.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
+                              "dependencies": {
+                                "extsprintf": {
+                                  "version": "1.0.2",
+                                  "from": "extsprintf@1.0.2",
+                                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                                },
+                                "json-schema": {
+                                  "version": "0.2.2",
+                                  "from": "json-schema@0.2.2",
+                                  "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                                },
+                                "verror": {
+                                  "version": "1.3.6",
+                                  "from": "verror@1.3.6",
+                                  "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                                }
+                              }
+                            },
+                            "sshpk": {
+                              "version": "1.9.1",
+                              "from": "sshpk@>=1.7.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.9.1.tgz",
+                              "dependencies": {
+                                "asn1": {
+                                  "version": "0.2.3",
+                                  "from": "asn1@>=0.2.3 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                                },
+                                "assert-plus": {
+                                  "version": "1.0.0",
+                                  "from": "assert-plus@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                                },
+                                "dashdash": {
+                                  "version": "1.14.0",
+                                  "from": "dashdash@>=1.12.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz"
+                                },
+                                "getpass": {
+                                  "version": "0.1.6",
+                                  "from": "getpass@>=0.1.1 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
+                                },
+                                "jsbn": {
+                                  "version": "0.1.0",
+                                  "from": "jsbn@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                                },
+                                "tweetnacl": {
+                                  "version": "0.13.3",
+                                  "from": "tweetnacl@>=0.13.0 <0.14.0",
+                                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+                                },
+                                "jodid25519": {
+                                  "version": "1.0.2",
+                                  "from": "jodid25519@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                                },
+                                "ecc-jsbn": {
+                                  "version": "0.1.1",
+                                  "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "is-typedarray": {
+                          "version": "1.0.0",
+                          "from": "is-typedarray@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                        },
+                        "isstream": {
+                          "version": "0.1.2",
+                          "from": "isstream@>=0.1.2 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                        },
+                        "json-stringify-safe": {
+                          "version": "5.0.1",
+                          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+                          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                        },
+                        "mime-types": {
+                          "version": "2.1.11",
+                          "from": "mime-types@>=2.1.7 <2.2.0",
+                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                          "dependencies": {
+                            "mime-db": {
+                              "version": "1.23.0",
+                              "from": "mime-db@>=1.23.0 <1.24.0",
+                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                            }
+                          }
+                        },
+                        "node-uuid": {
+                          "version": "1.4.7",
+                          "from": "node-uuid@>=1.4.7 <1.5.0",
+                          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                        },
+                        "oauth-sign": {
+                          "version": "0.8.2",
+                          "from": "oauth-sign@>=0.8.1 <0.9.0",
+                          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+                        },
+                        "qs": {
+                          "version": "6.2.1",
+                          "from": "qs@>=6.2.0 <6.3.0",
+                          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz"
+                        },
+                        "stringstream": {
+                          "version": "0.0.5",
+                          "from": "stringstream@>=0.0.4 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                        },
+                        "tough-cookie": {
+                          "version": "2.3.1",
+                          "from": "tough-cookie@>=2.3.0 <2.4.0",
+                          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
+                        },
+                        "tunnel-agent": {
+                          "version": "0.4.3",
+                          "from": "tunnel-agent@>=0.4.1 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "volos-swagger": {
+              "version": "0.8.0",
+              "from": "volos-swagger@>=0.8.0 <0.9.0",
+              "resolved": "https://registry.npmjs.org/volos-swagger/-/volos-swagger-0.8.0.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "1.5.2",
+                  "from": "async@>=1.5.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+                },
+                "underscore": {
+                  "version": "1.8.3",
+                  "from": "underscore@>=1.8.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
+                }
+              }
             }
           }
         },
-        "body-parser": {
-          "version": "1.12.4",
-          "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.4.tgz",
-          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.4.tgz",
+        "apigee-access": {
+          "version": "1.3.0",
+          "from": "apigee-access@>=1.3.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/apigee-access/-/apigee-access-1.3.0.tgz"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
-            "depd": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
-            },
-            "ee-first": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
-            },
-            "on-finished": {
-              "version": "2.2.1",
-              "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz"
-            },
-            "qs": {
-              "version": "2.4.2",
-              "from": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
+            "ms": {
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
-        },
-        "busboy": {
-          "version": "0.2.13",
-          "from": "https://registry.npmjs.org/busboy/-/busboy-0.2.13.tgz",
-          "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.13.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.1.13",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
-            }
-          }
-        },
-        "bytes": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
-        },
-        "component-emitter": {
-          "version": "1.2.0",
-          "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz"
-        },
-        "concat-stream": {
-          "version": "1.5.1",
-          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            },
-            "readable-stream": {
-              "version": "2.0.6",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-            }
-          }
-        },
-        "content-disposition": {
-          "version": "0.5.1",
-          "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
-          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
-        },
-        "cookie": {
-          "version": "0.1.5",
-          "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz"
-        },
-        "cookie-signature": {
-          "version": "1.0.6",
-          "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
-        },
-        "cookiejar": {
-          "version": "2.0.6",
-          "from": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz",
-          "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz"
-        },
-        "cors": {
-          "version": "2.7.1",
-          "from": "https://registry.npmjs.org/cors/-/cors-2.7.1.tgz",
-          "resolved": "https://registry.npmjs.org/cors/-/cors-2.7.1.tgz"
-        },
-        "destroy": {
-          "version": "1.0.4",
-          "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
-        },
-        "dicer": {
-          "version": "0.2.5",
-          "from": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
-          "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.1.13",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
-            }
-          }
-        },
-        "escape-html": {
-          "version": "1.0.3",
-          "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
-        },
-        "etag": {
-          "version": "1.7.0",
-          "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
-          "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
         },
         "express": {
-          "version": "4.13.4",
-          "from": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
-          "resolved": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
+          "version": "4.14.0",
+          "from": "express@>=4.13.4 <5.0.0",
+          "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
           "dependencies": {
-            "path-to-regexp": {
-              "version": "0.1.7",
-              "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-              "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+            "accepts": {
+              "version": "1.3.3",
+              "from": "accepts@>=1.3.3 <1.4.0",
+              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+              "dependencies": {
+                "mime-types": {
+                  "version": "2.1.11",
+                  "from": "mime-types@>=2.1.11 <2.2.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.23.0",
+                      "from": "mime-db@>=1.23.0 <1.24.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                    }
+                  }
+                },
+                "negotiator": {
+                  "version": "0.6.1",
+                  "from": "negotiator@0.6.1",
+                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+                }
+              }
             },
-            "vary": {
+            "array-flatten": {
+              "version": "1.1.1",
+              "from": "array-flatten@1.1.1",
+              "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
+            },
+            "content-disposition": {
+              "version": "0.5.1",
+              "from": "content-disposition@0.5.1",
+              "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
+            },
+            "content-type": {
+              "version": "1.0.2",
+              "from": "content-type@>=1.0.2 <1.1.0",
+              "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
+            },
+            "cookie": {
+              "version": "0.3.1",
+              "from": "cookie@0.3.1",
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
+            },
+            "cookie-signature": {
+              "version": "1.0.6",
+              "from": "cookie-signature@1.0.6",
+              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+            },
+            "depd": {
+              "version": "1.1.0",
+              "from": "depd@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+            },
+            "encodeurl": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
-            }
-          }
-        },
-        "finalhandler": {
-          "version": "0.4.1",
-          "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz"
-        },
-        "form-data": {
-          "version": "1.0.0-rc3",
-          "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
-        },
-        "forwarded": {
-          "version": "0.1.0",
-          "from": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
-        },
-        "fresh": {
-          "version": "0.3.0",
-          "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
-        },
-        "http-errors": {
-          "version": "1.3.1",
-          "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
-        },
-        "iconv-lite": {
-          "version": "0.4.8",
-          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz"
-        },
-        "ipaddr.js": {
-          "version": "1.0.5",
-          "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz",
-          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz"
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-        },
-        "js-yaml": {
-          "version": "3.6.1",
-          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz"
-        },
-        "json-refs": {
-          "version": "2.1.5",
-          "from": "https://registry.npmjs.org/json-refs/-/json-refs-2.1.5.tgz",
-          "resolved": "https://registry.npmjs.org/json-refs/-/json-refs-2.1.5.tgz"
-        },
-        "lodash": {
-          "version": "4.7.0",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-4.7.0.tgz",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.7.0.tgz"
-        },
-        "lodash-compat": {
-          "version": "3.10.2",
-          "from": "https://registry.npmjs.org/lodash-compat/-/lodash-compat-3.10.2.tgz",
-          "resolved": "https://registry.npmjs.org/lodash-compat/-/lodash-compat-3.10.2.tgz"
-        },
-        "lodash._arraypool": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz"
-        },
-        "lodash._basebind": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz"
-        },
-        "lodash._baseclone": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-2.4.1.tgz"
-        },
-        "lodash._basecreate": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz"
-        },
-        "lodash._basecreatecallback": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz"
-        },
-        "lodash._basecreatewrapper": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz"
-        },
-        "lodash._baseget": {
-          "version": "3.7.2",
-          "from": "https://registry.npmjs.org/lodash._baseget/-/lodash._baseget-3.7.2.tgz",
-          "resolved": "https://registry.npmjs.org/lodash._baseget/-/lodash._baseget-3.7.2.tgz"
-        },
-        "lodash._createwrapper": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz"
-        },
-        "lodash._getarray": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash._getarray/-/lodash._getarray-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash._getarray/-/lodash._getarray-2.4.1.tgz"
-        },
-        "lodash._isnative": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-        },
-        "lodash._maxpoolsize": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash._maxpoolsize/-/lodash._maxpoolsize-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash._maxpoolsize/-/lodash._maxpoolsize-2.4.1.tgz"
-        },
-        "lodash._objecttypes": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
-        },
-        "lodash._releasearray": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash._releasearray/-/lodash._releasearray-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash._releasearray/-/lodash._releasearray-2.4.1.tgz"
-        },
-        "lodash._setbinddata": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz"
-        },
-        "lodash._shimkeys": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
-        },
-        "lodash._slice": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz"
-        },
-        "lodash._topath": {
-          "version": "3.8.1",
-          "from": "https://registry.npmjs.org/lodash._topath/-/lodash._topath-3.8.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash._topath/-/lodash._topath-3.8.1.tgz",
-          "dependencies": {
-            "lodash.isarray": {
-              "version": "3.0.4",
-              "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-            }
-          }
-        },
-        "lodash.assign": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz"
-        },
-        "lodash.bind": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz"
-        },
-        "lodash.clonedeep": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-2.4.1.tgz"
-        },
-        "lodash.foreach": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-2.4.1.tgz"
-        },
-        "lodash.forown": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.4.1.tgz"
-        },
-        "lodash.get": {
-          "version": "3.7.0",
-          "from": "https://registry.npmjs.org/lodash.get/-/lodash.get-3.7.0.tgz",
-          "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-3.7.0.tgz"
-        },
-        "lodash.identity": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz"
-        },
-        "lodash.isarray": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-2.4.1.tgz"
-        },
-        "lodash.isfunction": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
-        },
-        "lodash.isobject": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
-        },
-        "lodash.keys": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
-        },
-        "lodash.noop": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
-        },
-        "lodash.support": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz"
-        },
-        "merge-descriptors": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
-        },
-        "methods": {
-          "version": "1.1.2",
-          "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
-        },
-        "multer": {
-          "version": "1.1.0",
-          "from": "https://registry.npmjs.org/multer/-/multer-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/multer/-/multer-1.1.0.tgz"
-        },
-        "native-promise-only": {
-          "version": "0.8.1",
-          "from": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-          "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz"
-        },
-        "object-assign": {
-          "version": "3.0.0",
-          "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
-        },
-        "parseurl": {
-          "version": "1.3.1",
-          "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
-        },
-        "path-loader": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/path-loader/-/path-loader-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/path-loader/-/path-loader-1.0.1.tgz"
-        },
-        "path-to-regexp": {
-          "version": "1.2.1",
-          "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.2.1.tgz"
-        },
-        "proxy-addr": {
-          "version": "1.0.10",
-          "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
-          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz"
-        },
-        "qs": {
-          "version": "4.0.0",
-          "from": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
-        },
-        "range-parser": {
-          "version": "1.0.3",
-          "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
-        },
-        "raw-body": {
-          "version": "2.0.2",
-          "from": "https://registry.npmjs.org/raw-body/-/raw-body-2.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.0.2.tgz",
-          "dependencies": {
-            "bytes": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz"
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "1.0.27-1",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz"
-        },
-        "reduce-component": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz"
-        },
-        "request": {
-          "version": "2.69.0",
-          "from": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
-          "dependencies": {
-            "qs": {
-              "version": "6.0.2",
-              "from": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
-            }
-          }
-        },
-        "semver": {
-          "version": "3.0.1",
-          "from": "https://registry.npmjs.org/semver/-/semver-3.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-3.0.1.tgz"
-        },
-        "send": {
-          "version": "0.13.1",
-          "from": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz"
-        },
-        "serve-static": {
-          "version": "1.10.2",
-          "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz",
-          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz"
-        },
-        "slash": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
-        },
-        "spark-md5": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/spark-md5/-/spark-md5-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-1.0.1.tgz"
-        },
-        "splitargs": {
-          "version": "0.0.3",
-          "from": "https://registry.npmjs.org/splitargs/-/splitargs-0.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/splitargs/-/splitargs-0.0.3.tgz"
-        },
-        "streamsearch": {
-          "version": "0.1.2",
-          "from": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz"
-        },
-        "string": {
-          "version": "3.3.1",
-          "from": "https://registry.npmjs.org/string/-/string-3.3.1.tgz",
-          "resolved": "https://registry.npmjs.org/string/-/string-3.3.1.tgz"
-        },
-        "superagent": {
-          "version": "1.8.3",
-          "from": "https://registry.npmjs.org/superagent/-/superagent-1.8.3.tgz",
-          "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.8.3.tgz",
-          "dependencies": {
-            "qs": {
-              "version": "2.3.3",
-              "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
-            }
-          }
-        },
-        "swagger-converter": {
-          "version": "0.1.7",
-          "from": "https://registry.npmjs.org/swagger-converter/-/swagger-converter-0.1.7.tgz",
-          "resolved": "https://registry.npmjs.org/swagger-converter/-/swagger-converter-0.1.7.tgz"
-        },
-        "swagger-docs": {
-          "version": "0.0.0-alpha2",
-          "from": "https://registry.npmjs.org/swagger-docs/-/swagger-docs-0.0.0-alpha2.tgz",
-          "resolved": "https://registry.npmjs.org/swagger-docs/-/swagger-docs-0.0.0-alpha2.tgz"
-        },
-        "swagger-tools": {
-          "version": "0.10.1",
-          "from": "https://registry.npmjs.org/swagger-tools/-/swagger-tools-0.10.1.tgz",
-          "resolved": "https://registry.npmjs.org/swagger-tools/-/swagger-tools-0.10.1.tgz"
-        },
-        "traverse": {
-          "version": "0.6.6",
-          "from": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-          "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
-        },
-        "uri-js": {
-          "version": "2.1.1",
-          "from": "https://registry.npmjs.org/uri-js/-/uri-js-2.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-2.1.1.tgz"
-        },
-        "utils-merge": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
-        },
-        "validator": {
-          "version": "4.9.0",
-          "from": "https://registry.npmjs.org/validator/-/validator-4.9.0.tgz",
-          "resolved": "https://registry.npmjs.org/validator/-/validator-4.9.0.tgz"
-        },
-        "vary": {
-          "version": "1.1.0",
-          "from": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
-        },
-        "volos-oauth-apigee": {
-          "version": "0.10.8",
-          "from": "https://registry.npmjs.org/volos-oauth-apigee/-/volos-oauth-apigee-0.10.8.tgz",
-          "resolved": "https://registry.npmjs.org/volos-oauth-apigee/-/volos-oauth-apigee-0.10.8.tgz",
-          "dependencies": {
-            "async": {
-              "version": "0.9.2",
-              "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+              "from": "encodeurl@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
             },
-            "combined-stream": {
-              "version": "0.0.7",
-              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz"
+            "escape-html": {
+              "version": "1.0.3",
+              "from": "escape-html@>=1.0.3 <1.1.0",
+              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
             },
-            "component-emitter": {
-              "version": "1.1.2",
-              "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+            "etag": {
+              "version": "1.7.0",
+              "from": "etag@>=1.7.0 <1.8.0",
+              "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
             },
-            "cookiejar": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.1.tgz"
+            "finalhandler": {
+              "version": "0.5.0",
+              "from": "finalhandler@0.5.0",
+              "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
+              "dependencies": {
+                "statuses": {
+                  "version": "1.3.0",
+                  "from": "statuses@>=1.3.0 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
+                },
+                "unpipe": {
+                  "version": "1.0.0",
+                  "from": "unpipe@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+                }
+              }
             },
-            "debug": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz"
+            "fresh": {
+              "version": "0.3.0",
+              "from": "fresh@0.3.0",
+              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
             },
-            "delayed-stream": {
-              "version": "0.0.5",
-              "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-            },
-            "extend": {
-              "version": "1.2.1",
-              "from": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz"
-            },
-            "form-data": {
-              "version": "0.1.3",
-              "from": "https://registry.npmjs.org/form-data/-/form-data-0.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.3.tgz"
-            },
-            "formidable": {
-              "version": "1.0.14",
-              "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz",
-              "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz"
+            "merge-descriptors": {
+              "version": "1.0.1",
+              "from": "merge-descriptors@1.0.1",
+              "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
             },
             "methods": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz"
+              "version": "1.1.2",
+              "from": "methods@>=1.1.2 <1.2.0",
+              "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
             },
-            "mime": {
-              "version": "1.2.11",
-              "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+            "on-finished": {
+              "version": "2.3.0",
+              "from": "on-finished@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+              "dependencies": {
+                "ee-first": {
+                  "version": "1.1.1",
+                  "from": "ee-first@1.1.1",
+                  "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+                }
+              }
             },
-            "ms": {
-              "version": "0.6.2",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+            "parseurl": {
+              "version": "1.3.1",
+              "from": "parseurl@>=1.3.1 <1.4.0",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+            },
+            "path-to-regexp": {
+              "version": "0.1.7",
+              "from": "path-to-regexp@0.1.7",
+              "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+            },
+            "proxy-addr": {
+              "version": "1.1.2",
+              "from": "proxy-addr@>=1.1.2 <1.2.0",
+              "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
+              "dependencies": {
+                "forwarded": {
+                  "version": "0.1.0",
+                  "from": "forwarded@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
+                },
+                "ipaddr.js": {
+                  "version": "1.1.1",
+                  "from": "ipaddr.js@1.1.1",
+                  "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
+                }
+              }
             },
             "qs": {
-              "version": "1.2.0",
-              "from": "https://registry.npmjs.org/qs/-/qs-1.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.0.tgz"
+              "version": "6.2.0",
+              "from": "qs@6.2.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
             },
-            "superagent": {
-              "version": "0.21.0",
-              "from": "https://registry.npmjs.org/superagent/-/superagent-0.21.0.tgz",
-              "resolved": "https://registry.npmjs.org/superagent/-/superagent-0.21.0.tgz",
+            "range-parser": {
+              "version": "1.2.0",
+              "from": "range-parser@>=1.2.0 <1.3.0",
+              "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
+            },
+            "send": {
+              "version": "0.14.1",
+              "from": "send@0.14.1",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
               "dependencies": {
-                "debug": {
-                  "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+                "destroy": {
+                  "version": "1.0.4",
+                  "from": "destroy@>=1.0.4 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+                },
+                "http-errors": {
+                  "version": "1.5.0",
+                  "from": "http-errors@>=1.5.0 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "setprototypeof": {
+                      "version": "1.0.1",
+                      "from": "setprototypeof@1.0.1",
+                      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.3.4",
+                  "from": "mime@1.3.4",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                 },
                 "ms": {
                   "version": "0.7.1",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "from": "ms@0.7.1",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                },
+                "statuses": {
+                  "version": "1.3.0",
+                  "from": "statuses@>=1.3.0 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
+                }
+              }
+            },
+            "serve-static": {
+              "version": "1.11.1",
+              "from": "serve-static@>=1.11.1 <1.12.0",
+              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz"
+            },
+            "type-is": {
+              "version": "1.6.13",
+              "from": "type-is@>=1.6.13 <1.7.0",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+              "dependencies": {
+                "media-typer": {
+                  "version": "0.3.0",
+                  "from": "media-typer@0.3.0",
+                  "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+                },
+                "mime-types": {
+                  "version": "2.1.11",
+                  "from": "mime-types@>=2.1.11 <2.2.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.23.0",
+                      "from": "mime-db@>=1.23.0 <1.24.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "utils-merge": {
+              "version": "1.0.0",
+              "from": "utils-merge@1.0.0",
+              "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+            },
+            "vary": {
+              "version": "1.1.0",
+              "from": "vary@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
+            }
+          }
+        },
+        "js-yaml": {
+          "version": "3.6.1",
+          "from": "js-yaml@>=3.5.4 <4.0.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.7",
+              "from": "argparse@>=1.0.7 <2.0.0",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
+              "dependencies": {
+                "sprintf-js": {
+                  "version": "1.0.3",
+                  "from": "sprintf-js@>=1.0.2 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.7.2",
+              "from": "esprima@>=2.6.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+            }
+          }
+        },
+        "jsonwebtoken": {
+          "version": "5.7.0",
+          "from": "jsonwebtoken@>=5.0.1 <6.0.0",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz",
+          "dependencies": {
+            "jws": {
+              "version": "3.1.3",
+              "from": "jws@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.3.tgz",
+              "dependencies": {
+                "base64url": {
+                  "version": "1.0.6",
+                  "from": "base64url@>=1.0.4 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
+                  "dependencies": {
+                    "concat-stream": {
+                      "version": "1.4.10",
+                      "from": "concat-stream@>=1.4.7 <1.5.0",
+                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "from": "typedarray@>=0.0.5 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                        },
+                        "readable-stream": {
+                          "version": "1.1.14",
+                          "from": "readable-stream@>=1.1.9 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "meow": {
+                      "version": "2.0.0",
+                      "from": "meow@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
+                      "dependencies": {
+                        "camelcase-keys": {
+                          "version": "1.0.0",
+                          "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "1.2.1",
+                              "from": "camelcase@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                            },
+                            "map-obj": {
+                              "version": "1.0.1",
+                              "from": "map-obj@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "indent-string": {
+                          "version": "1.2.2",
+                          "from": "indent-string@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                          "dependencies": {
+                            "get-stdin": {
+                              "version": "4.0.1",
+                              "from": "get-stdin@>=4.0.1 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                            },
+                            "repeating": {
+                              "version": "1.1.3",
+                              "from": "repeating@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.1",
+                                  "from": "is-finite@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.0",
+                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "minimist@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                        },
+                        "object-assign": {
+                          "version": "1.0.0",
+                          "from": "object-assign@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "jwa": {
+                  "version": "1.1.3",
+                  "from": "jwa@>=1.1.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.3.tgz",
+                  "dependencies": {
+                    "buffer-equal-constant-time": {
+                      "version": "1.0.1",
+                      "from": "buffer-equal-constant-time@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
+                    },
+                    "ecdsa-sig-formatter": {
+                      "version": "1.0.7",
+                      "from": "ecdsa-sig-formatter@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.7.tgz",
+                      "dependencies": {
+                        "base64-url": {
+                          "version": "1.3.2",
+                          "from": "base64-url@>=1.2.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.3.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "ms": {
+              "version": "0.7.1",
+              "from": "ms@>=0.7.1 <0.8.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "from": "xtend@>=4.0.1 <5.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+            }
+          }
+        },
+        "volos-oauth-apigee": {
+          "version": "0.10.8",
+          "from": "volos-oauth-apigee@>=0.10.8 <0.11.0",
+          "resolved": "https://registry.npmjs.org/volos-oauth-apigee/-/volos-oauth-apigee-0.10.8.tgz",
+          "dependencies": {
+            "volos-oauth-common": {
+              "version": "0.10.5",
+              "from": "volos-oauth-common@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/volos-oauth-common/-/volos-oauth-common-0.10.5.tgz"
+            },
+            "debug": {
+              "version": "1.0.4",
+              "from": "debug@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            },
+            "semver": {
+              "version": "3.0.1",
+              "from": "semver@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-3.0.1.tgz"
+            },
+            "superagent": {
+              "version": "0.21.0",
+              "from": "superagent@>=0.0.0 <1.0.0",
+              "resolved": "https://registry.npmjs.org/superagent/-/superagent-0.21.0.tgz",
+              "dependencies": {
+                "qs": {
+                  "version": "1.2.0",
+                  "from": "qs@1.2.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.0.tgz"
+                },
+                "formidable": {
+                  "version": "1.0.14",
+                  "from": "formidable@1.0.14",
+                  "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz"
+                },
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "mime@1.2.11",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                },
+                "component-emitter": {
+                  "version": "1.1.2",
+                  "from": "component-emitter@1.1.2",
+                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                },
+                "methods": {
+                  "version": "1.0.1",
+                  "from": "methods@1.0.1",
+                  "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz"
+                },
+                "cookiejar": {
+                  "version": "2.0.1",
+                  "from": "cookiejar@2.0.1",
+                  "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.1.tgz"
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "debug@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "ms@0.7.1",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    }
+                  }
+                },
+                "reduce-component": {
+                  "version": "1.0.1",
+                  "from": "reduce-component@1.0.1",
+                  "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz"
+                },
+                "extend": {
+                  "version": "1.2.1",
+                  "from": "extend@>=1.2.1 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz"
+                },
+                "form-data": {
+                  "version": "0.1.3",
+                  "from": "form-data@0.1.3",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.3.tgz",
+                  "dependencies": {
+                    "combined-stream": {
+                      "version": "0.0.7",
+                      "from": "combined-stream@>=0.0.4 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                        }
+                      }
+                    },
+                    "async": {
+                      "version": "0.9.2",
+                      "from": "async@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "1.0.27-1",
+                  "from": "readable-stream@1.0.27-1",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
                 }
               }
             },
             "underscore": {
               "version": "1.6.0",
-              "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+              "from": "underscore@>=1.6.0 <1.7.0",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
             }
           }
-        },
-        "volos-oauth-common": {
-          "version": "0.10.5",
-          "from": "https://registry.npmjs.org/volos-oauth-common/-/volos-oauth-common-0.10.5.tgz",
-          "resolved": "https://registry.npmjs.org/volos-oauth-common/-/volos-oauth-common-0.10.5.tgz",
-          "dependencies": {
-            "debug": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz"
-            },
-            "ms": {
-              "version": "0.6.2",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-            },
-            "underscore": {
-              "version": "1.6.0",
-              "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
-            }
-          }
-        },
-        "volos-swagger": {
-          "version": "0.8.0",
-          "from": "https://registry.npmjs.org/volos-swagger/-/volos-swagger-0.8.0.tgz",
-          "resolved": "https://registry.npmjs.org/volos-swagger/-/volos-swagger-0.8.0.tgz"
-        },
-        "z-schema": {
-          "version": "3.16.1",
-          "from": "https://registry.npmjs.org/z-schema/-/z-schema-3.16.1.tgz",
-          "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.16.1.tgz"
         }
       }
     },
     "microgateway-plugins": {
       "version": "2.0.4",
-      "from": "microgateway-plugins@2.0.4"
-    },
-    "mime": {
-      "version": "1.3.4",
-      "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
-    },
-    "mime-db": {
-      "version": "1.22.0",
-      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
-    },
-    "mime-types": {
-      "version": "2.1.10",
-      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz"
-    },
-    "minimatch": {
-      "version": "3.0.0",
-      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
-    },
-    "minimist": {
-      "version": "1.2.0",
-      "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-    },
-    "mkdirp": {
-      "version": "0.5.1",
-      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "from": "microgateway-plugins@>=2.0.4 <3.0.0",
+      "resolved": "https://registry.npmjs.org/microgateway-plugins/-/microgateway-plugins-2.0.4.tgz",
       "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        "volos-spikearrest-memory": {
+          "version": "0.10.1",
+          "from": "volos-spikearrest-memory@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/volos-spikearrest-memory/-/volos-spikearrest-memory-0.10.1.tgz",
+          "dependencies": {
+            "volos-spikearrest-common": {
+              "version": "0.10.3",
+              "from": "volos-spikearrest-common@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/volos-spikearrest-common/-/volos-spikearrest-common-0.10.3.tgz",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.6.0",
+                  "from": "underscore@>=1.6.0 <1.7.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "volos-quota-memory": {
+          "version": "0.11.1",
+          "from": "volos-quota-memory@>=0.11.0 <0.12.0",
+          "resolved": "https://registry.npmjs.org/volos-quota-memory/-/volos-quota-memory-0.11.1.tgz",
+          "dependencies": {
+            "volos-quota-common": {
+              "version": "0.11.3",
+              "from": "volos-quota-common@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/volos-quota-common/-/volos-quota-common-0.11.3.tgz",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.6.0",
+                  "from": "underscore@>=1.6.0 <1.7.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "volos-quota-apigee": {
+          "version": "0.13.1",
+          "from": "volos-quota-apigee@>=0.13.0 <0.14.0",
+          "resolved": "https://registry.npmjs.org/volos-quota-apigee/-/volos-quota-apigee-0.13.1.tgz",
+          "dependencies": {
+            "apigee-access": {
+              "version": "1.3.0",
+              "from": "apigee-access@>=1.2.0",
+              "resolved": "https://registry.npmjs.org/apigee-access/-/apigee-access-1.3.0.tgz"
+            },
+            "semver": {
+              "version": "3.0.1",
+              "from": "semver@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-3.0.1.tgz"
+            },
+            "volos-quota-common": {
+              "version": "0.11.3",
+              "from": "volos-quota-common@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/volos-quota-common/-/volos-quota-common-0.11.3.tgz",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.6.0",
+                  "from": "underscore@>=1.6.0 <1.7.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "volos-cache-memory": {
+          "version": "0.10.1",
+          "from": "volos-cache-memory@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/volos-cache-memory/-/volos-cache-memory-0.10.1.tgz",
+          "dependencies": {
+            "volos-cache-common": {
+              "version": "0.10.6",
+              "from": "volos-cache-common@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/volos-cache-common/-/volos-cache-common-0.10.6.tgz",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.6.0",
+                  "from": "underscore@>=1.6.0 <1.7.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+                }
+              }
+            },
+            "lru-cache-plus": {
+              "version": "2.5.0",
+              "from": "lru-cache-plus@>=2.5.0 <2.6.0",
+              "resolved": "https://registry.npmjs.org/lru-cache-plus/-/lru-cache-plus-2.5.0.tgz"
+            }
+          }
+        },
+        "volos-analytics-apigee": {
+          "version": "0.4.2",
+          "from": "volos-analytics-apigee@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/volos-analytics-apigee/-/volos-analytics-apigee-0.4.2.tgz",
+          "dependencies": {
+            "on-finished": {
+              "version": "2.2.1",
+              "from": "on-finished@>=2.2.1 <2.3.0",
+              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
+              "dependencies": {
+                "ee-first": {
+                  "version": "1.1.0",
+                  "from": "ee-first@1.1.0",
+                  "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
+                }
+              }
+            },
+            "volos-analytics-common": {
+              "version": "0.2.4",
+              "from": "volos-analytics-common@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/volos-analytics-common/-/volos-analytics-common-0.2.4.tgz"
+            }
+          }
         }
       }
-    },
-    "mocha": {
-      "version": "2.4.5",
-      "from": "https://registry.npmjs.org/mocha/-/mocha-2.4.5.tgz",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.4.5.tgz",
-      "dependencies": {
-        "commander": {
-          "version": "2.3.0",
-          "from": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
-        },
-        "escape-string-regexp": {
-          "version": "1.0.2",
-          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-        },
-        "glob": {
-          "version": "3.2.3",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz"
-        },
-        "graceful-fs": {
-          "version": "2.0.3",
-          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
-        },
-        "lru-cache": {
-          "version": "2.7.3",
-          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-        },
-        "minimatch": {
-          "version": "0.2.14",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
-        },
-        "supports-color": {
-          "version": "1.2.0",
-          "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz"
-        }
-      }
-    },
-    "moment": {
-      "version": "2.12.0",
-      "from": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz"
-    },
-    "ms": {
-      "version": "0.7.1",
-      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-    },
-    "multipipe": {
-      "version": "0.1.2",
-      "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz"
-    },
-    "mustache": {
-      "version": "2.2.1",
-      "from": "https://registry.npmjs.org/mustache/-/mustache-2.2.1.tgz",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.2.1.tgz"
-    },
-    "mute-stream": {
-      "version": "0.0.6",
-      "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz"
-    },
-    "mv": {
-      "version": "2.1.1",
-      "from": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
-      "dependencies": {
-        "glob": {
-          "version": "6.0.4",
-          "from": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz"
-        },
-        "rimraf": {
-          "version": "2.4.5",
-          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz"
-        }
-      }
-    },
-    "nan": {
-      "version": "2.2.1",
-      "from": "https://registry.npmjs.org/nan/-/nan-2.2.1.tgz",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.1.tgz"
-    },
-    "ncp": {
-      "version": "2.0.0",
-      "from": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
-    },
-    "negotiator": {
-      "version": "0.5.3",
-      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
-    },
-    "node-unzip-2": {
-      "version": "0.2.1",
-      "from": "https://registry.npmjs.org/node-unzip-2/-/node-unzip-2-0.2.1.tgz",
-      "resolved": "https://registry.npmjs.org/node-unzip-2/-/node-unzip-2-0.2.1.tgz",
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-        }
-      }
-    },
-    "node-uuid": {
-      "version": "1.4.7",
-      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-    },
-    "node-zip": {
-      "version": "1.1.1",
-      "from": "https://registry.npmjs.org/node-zip/-/node-zip-1.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/node-zip/-/node-zip-1.1.1.tgz"
-    },
-    "normalize-package-data": {
-      "version": "2.3.5",
-      "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
-    },
-    "number-is-nan": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-    },
-    "oauth-sign": {
-      "version": "0.8.1",
-      "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
-    },
-    "object-assign": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
-    },
-    "on-finished": {
-      "version": "2.3.0",
-      "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
-    },
-    "once": {
-      "version": "1.3.3",
-      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
-    },
-    "orchestrator": {
-      "version": "0.3.7",
-      "from": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
-      "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz"
-    },
-    "ordered-read-streams": {
-      "version": "0.1.0",
-      "from": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
-    },
-    "os-homedir": {
-      "version": "1.0.1",
-      "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-    },
-    "os-tmpdir": {
-      "version": "1.0.1",
-      "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-    },
-    "over": {
-      "version": "0.0.5",
-      "from": "https://registry.npmjs.org/over/-/over-0.0.5.tgz",
-      "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz"
-    },
-    "pako": {
-      "version": "0.2.8",
-      "from": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
-    },
-    "parse-json": {
-      "version": "2.2.0",
-      "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
-    },
-    "path-exists": {
-      "version": "2.1.0",
-      "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
-    },
-    "path-is-absolute": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-    },
-    "path-type": {
-      "version": "1.1.0",
-      "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
     },
     "pem": {
-      "version": "1.8.1",
-      "from": "https://registry.npmjs.org/pem/-/pem-1.8.1.tgz",
-      "resolved": "https://registry.npmjs.org/pem/-/pem-1.8.1.tgz"
-    },
-    "pify": {
-      "version": "2.3.0",
-      "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-    },
-    "pkginfo": {
-      "version": "0.3.1",
-      "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
-      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
-    },
-    "precond": {
-      "version": "0.2.3",
-      "from": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
-      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz"
-    },
-    "pretty-hrtime": {
-      "version": "1.0.2",
-      "from": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.2.tgz"
-    },
-    "process-nextick-args": {
-      "version": "1.0.6",
-      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "from": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
-    },
-    "pullstream": {
-      "version": "0.4.1",
-      "from": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
-      "resolved": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
+      "version": "1.8.3",
+      "from": "pem@>=1.8.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/pem/-/pem-1.8.3.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+        "os-tmpdir": {
+          "version": "1.0.1",
+          "from": "os-tmpdir@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
         },
-        "readable-stream": {
-          "version": "1.0.34",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+        "which": {
+          "version": "1.2.10",
+          "from": "which@>=1.2.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz",
+          "dependencies": {
+            "isexe": {
+              "version": "1.1.2",
+              "from": "isexe@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
+            }
+          }
         }
       }
-    },
-    "qs": {
-      "version": "6.1.0",
-      "from": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz"
-    },
-    "raw-body": {
-      "version": "2.1.6",
-      "from": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz",
-      "dependencies": {
-        "bytes": {
-          "version": "2.3.0",
-          "from": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz"
-        }
-      }
-    },
-    "read": {
-      "version": "1.0.7",
-      "from": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz"
-    },
-    "read-pkg": {
-      "version": "1.1.0",
-      "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
-    },
-    "read-pkg-up": {
-      "version": "1.0.1",
-      "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
-    },
-    "readable-stream": {
-      "version": "2.0.6",
-      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-    },
-    "rechoir": {
-      "version": "0.6.2",
-      "from": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
-    },
-    "redent": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-      "dependencies": {
-        "indent-string": {
-          "version": "2.1.0",
-          "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz"
-        },
-        "repeating": {
-          "version": "2.0.1",
-          "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
-        }
-      }
-    },
-    "repeating": {
-      "version": "1.1.3",
-      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
-    },
-    "replace-ext": {
-      "version": "0.0.1",
-      "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
     },
     "request": {
-      "version": "2.71.0",
-      "from": "https://registry.npmjs.org/request/-/request-2.71.0.tgz",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.71.0.tgz"
-    },
-    "resolve": {
-      "version": "1.1.7",
-      "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
-    },
-    "restify": {
-      "version": "4.0.4",
-      "from": "https://registry.npmjs.org/restify/-/restify-4.0.4.tgz",
-      "resolved": "https://registry.npmjs.org/restify/-/restify-4.0.4.tgz",
+      "version": "2.74.0",
+      "from": "request@>=2.67.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
       "dependencies": {
-        "asn1": {
-          "version": "0.1.11",
-          "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+        "aws-sign2": {
+          "version": "0.6.0",
+          "from": "aws-sign2@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
         },
-        "assert-plus": {
-          "version": "0.1.5",
-          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+        "aws4": {
+          "version": "1.4.1",
+          "from": "aws4@>=1.2.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
         },
-        "extsprintf": {
-          "version": "1.2.0",
-          "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz"
+        "bl": {
+          "version": "1.1.2",
+          "from": "bl@>=1.1.2 <1.2.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.0.6",
+              "from": "readable-stream@>=2.0.5 <2.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "from": "caseless@>=0.11.0 <0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "from": "combined-stream@>=1.0.5 <1.1.0",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "dependencies": {
+            "delayed-stream": {
+              "version": "1.0.0",
+              "from": "delayed-stream@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+            }
+          }
+        },
+        "extend": {
+          "version": "3.0.0",
+          "from": "extend@>=3.0.0 <3.1.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "from": "forever-agent@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+        },
+        "form-data": {
+          "version": "1.0.0-rc4",
+          "from": "form-data@>=1.0.0-rc4 <1.1.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "from": "har-validator@>=2.0.6 <2.1.0",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.3",
+              "from": "chalk@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                }
+              }
+            },
+            "is-my-json-valid": {
+              "version": "2.13.1",
+              "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+              "dependencies": {
+                "generate-function": {
+                  "version": "2.0.0",
+                  "from": "generate-function@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                },
+                "generate-object-property": {
+                  "version": "1.2.0",
+                  "from": "generate-object-property@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                  "dependencies": {
+                    "is-property": {
+                      "version": "1.0.2",
+                      "from": "is-property@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                    }
+                  }
+                },
+                "jsonpointer": {
+                  "version": "2.0.0",
+                  "from": "jsonpointer@2.0.0",
+                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                }
+              }
+            },
+            "pinkie-promise": {
+              "version": "2.0.1",
+              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+              "dependencies": {
+                "pinkie": {
+                  "version": "2.0.4",
+                  "from": "pinkie@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                }
+              }
+            }
+          }
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "from": "hawk@>=3.1.3 <3.2.0",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "dependencies": {
+            "hoek": {
+              "version": "2.16.3",
+              "from": "hoek@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+            },
+            "boom": {
+              "version": "2.10.1",
+              "from": "boom@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+            },
+            "cryptiles": {
+              "version": "2.0.5",
+              "from": "cryptiles@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+            },
+            "sntp": {
+              "version": "1.0.9",
+              "from": "sntp@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+            }
+          }
         },
         "http-signature": {
-          "version": "0.11.0",
-          "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz"
+          "version": "1.1.1",
+          "from": "http-signature@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "dependencies": {
+            "assert-plus": {
+              "version": "0.2.0",
+              "from": "assert-plus@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+            },
+            "jsprim": {
+              "version": "1.3.0",
+              "from": "jsprim@>=1.2.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
+              "dependencies": {
+                "extsprintf": {
+                  "version": "1.0.2",
+                  "from": "extsprintf@1.0.2",
+                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                },
+                "json-schema": {
+                  "version": "0.2.2",
+                  "from": "json-schema@0.2.2",
+                  "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                },
+                "verror": {
+                  "version": "1.3.6",
+                  "from": "verror@1.3.6",
+                  "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                }
+              }
+            },
+            "sshpk": {
+              "version": "1.9.1",
+              "from": "sshpk@>=1.7.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.9.1.tgz",
+              "dependencies": {
+                "asn1": {
+                  "version": "0.2.3",
+                  "from": "asn1@>=0.2.3 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                },
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "from": "assert-plus@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                },
+                "dashdash": {
+                  "version": "1.14.0",
+                  "from": "dashdash@>=1.12.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz"
+                },
+                "getpass": {
+                  "version": "0.1.6",
+                  "from": "getpass@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
+                },
+                "jsbn": {
+                  "version": "0.1.0",
+                  "from": "jsbn@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                },
+                "tweetnacl": {
+                  "version": "0.13.3",
+                  "from": "tweetnacl@>=0.13.0 <0.14.0",
+                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+                },
+                "jodid25519": {
+                  "version": "1.0.2",
+                  "from": "jodid25519@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                },
+                "ecc-jsbn": {
+                  "version": "0.1.1",
+                  "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                }
+              }
+            }
+          }
         },
-        "lru-cache": {
-          "version": "2.7.3",
-          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+        "is-typedarray": {
+          "version": "1.0.0",
+          "from": "is-typedarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "from": "isstream@>=0.1.2 <0.2.0",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+        },
+        "mime-types": {
+          "version": "2.1.11",
+          "from": "mime-types@>=2.1.7 <2.2.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+          "dependencies": {
+            "mime-db": {
+              "version": "1.23.0",
+              "from": "mime-db@>=1.23.0 <1.24.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+            }
+          }
+        },
+        "node-uuid": {
+          "version": "1.4.7",
+          "from": "node-uuid@>=1.4.7 <1.5.0",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "from": "oauth-sign@>=0.8.1 <0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
         },
         "qs": {
-          "version": "3.1.0",
-          "from": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz"
+          "version": "6.2.1",
+          "from": "qs@>=6.2.0 <6.3.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz"
         },
-        "verror": {
-          "version": "1.6.1",
-          "from": "https://registry.npmjs.org/verror/-/verror-1.6.1.tgz",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.1.tgz"
+        "stringstream": {
+          "version": "0.0.5",
+          "from": "stringstream@>=0.0.4 <0.1.0",
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+        },
+        "tough-cookie": {
+          "version": "2.3.1",
+          "from": "tough-cookie@>=2.3.0 <2.4.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "from": "tunnel-agent@>=0.4.1 <0.5.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
         }
       }
     },
     "rimraf": {
-      "version": "2.5.2",
-      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz"
-    },
-    "run-sequence": {
-      "version": "1.2.0",
-      "from": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.2.0.tgz"
-    },
-    "safe-json-stringify": {
-      "version": "1.0.3",
-      "from": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
-      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz"
-    },
-    "sax": {
-      "version": "1.2.1",
-      "from": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz"
-    },
-    "semver": {
-      "version": "4.3.6",
-      "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
-    },
-    "sequencify": {
-      "version": "0.0.7",
-      "from": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
-      "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz"
-    },
-    "setimmediate": {
-      "version": "1.0.4",
-      "from": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz"
-    },
-    "sigmund": {
-      "version": "1.0.1",
-      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-    },
-    "signal-exit": {
-      "version": "2.1.2",
-      "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
-    },
-    "slice-stream": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/slice-stream/-/slice-stream-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/slice-stream/-/slice-stream-1.0.0.tgz",
+      "version": "2.5.4",
+      "from": "rimraf@>=2.4.3 <3.0.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+        "glob": {
+          "version": "7.0.5",
+          "from": "glob@>=7.0.5 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
+          "dependencies": {
+            "fs.realpath": {
+              "version": "1.0.0",
+              "from": "fs.realpath@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+            },
+            "inflight": {
+              "version": "1.0.5",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "3.0.2",
+              "from": "minimatch@>=3.0.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.6",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.4.2",
+                      "from": "balanced-match@>=0.4.1 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.3",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+            }
+          }
         }
       }
-    },
-    "sntp": {
-      "version": "1.0.9",
-      "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-    },
-    "sparkles": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
-    },
-    "spdx-correct": {
-      "version": "1.0.2",
-      "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
-    },
-    "spdx-exceptions": {
-      "version": "1.0.4",
-      "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
-    },
-    "spdx-expression-parse": {
-      "version": "1.0.2",
-      "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz"
-    },
-    "spdx-license-ids": {
-      "version": "1.2.1",
-      "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
-    },
-    "spdy": {
-      "version": "1.32.5",
-      "from": "https://registry.npmjs.org/spdy/-/spdy-1.32.5.tgz",
-      "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.32.5.tgz"
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-    },
-    "sshpk": {
-      "version": "1.7.4",
-      "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz"
-    },
-    "stack-trace": {
-      "version": "0.0.9",
-      "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
-    },
-    "statuses": {
-      "version": "1.2.1",
-      "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
-    },
-    "stream-consume": {
-      "version": "0.1.0",
-      "from": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
-    },
-    "stream-transform": {
-      "version": "0.1.1",
-      "from": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.1.1.tgz"
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-    },
-    "strip-bom": {
-      "version": "2.0.0",
-      "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
-    },
-    "strip-indent": {
-      "version": "1.0.1",
-      "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
-    },
-    "supports-color": {
-      "version": "2.0.0",
-      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-    },
-    "temp": {
-      "version": "0.8.3",
-      "from": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
-      "dependencies": {
-        "rimraf": {
-          "version": "2.2.8",
-          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-        }
-      }
-    },
-    "through2": {
-      "version": "2.0.1",
-      "from": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
-    },
-    "through2-filter": {
-      "version": "2.0.0",
-      "from": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz"
-    },
-    "tildify": {
-      "version": "1.2.0",
-      "from": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz"
-    },
-    "time-stamp": {
-      "version": "1.0.1",
-      "from": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz"
     },
     "tmp": {
       "version": "0.0.28",
-      "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz"
-    },
-    "tough-cookie": {
-      "version": "2.2.2",
-      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
-    },
-    "traverse": {
-      "version": "0.3.9",
-      "from": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
-    },
-    "trim-newlines": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
-    },
-    "tunnel-agent": {
-      "version": "0.4.2",
-      "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
-    },
-    "tweetnacl": {
-      "version": "0.14.3",
-      "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
-    },
-    "type-is": {
-      "version": "1.6.12",
-      "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz"
-    },
-    "typedarray": {
-      "version": "0.0.6",
-      "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-    },
-    "typescript": {
-      "version": "1.8.10",
-      "from": "https://registry.npmjs.org/typescript/-/typescript-1.8.10.tgz",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.8.10.tgz"
-    },
-    "underscore": {
-      "version": "1.8.3",
-      "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
-    },
-    "unique-stream": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
-    },
-    "unpipe": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
-    },
-    "user-home": {
-      "version": "1.1.1",
-      "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+      "from": "tmp@0.0.28",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
+      "dependencies": {
+        "os-tmpdir": {
+          "version": "1.0.1",
+          "from": "os-tmpdir@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+        }
+      }
     },
     "util": {
       "version": "0.10.3",
-      "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+      "from": "util@>=0.10.3 <0.11.0",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "from": "inherits@2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+        }
+      }
     },
     "uuid": {
       "version": "2.0.2",
-      "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
+      "from": "uuid@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz"
     },
-    "v8flags": {
-      "version": "2.0.11",
-      "from": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz"
-    },
-    "validate-npm-package-license": {
-      "version": "3.0.1",
-      "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
-    },
-    "vasync": {
-      "version": "1.6.3",
-      "from": "https://registry.npmjs.org/vasync/-/vasync-1.6.3.tgz",
-      "resolved": "https://registry.npmjs.org/vasync/-/vasync-1.6.3.tgz",
-      "dependencies": {
-        "extsprintf": {
-          "version": "1.2.0",
-          "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz"
-        },
-        "verror": {
-          "version": "1.6.0",
-          "from": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz"
-        }
-      }
-    },
-    "verror": {
-      "version": "1.3.6",
-      "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-    },
-    "vinyl": {
-      "version": "0.5.3",
-      "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
-    },
-    "vinyl-fs": {
-      "version": "0.3.14",
-      "from": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-      "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-      "dependencies": {
-        "clone": {
-          "version": "0.2.0",
-          "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
-        },
-        "graceful-fs": {
-          "version": "3.0.8",
-          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-        },
-        "strip-bom": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz"
-        },
-        "through2": {
-          "version": "0.6.5",
-          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
-        },
-        "vinyl": {
-          "version": "0.4.6",
-          "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
-        }
-      }
-    },
-    "volos-analytics-apigee": {
-      "version": "0.4.2",
-      "from": "https://registry.npmjs.org/volos-analytics-apigee/-/volos-analytics-apigee-0.4.2.tgz",
-      "resolved": "https://registry.npmjs.org/volos-analytics-apigee/-/volos-analytics-apigee-0.4.2.tgz",
-      "dependencies": {
-        "ee-first": {
-          "version": "1.1.0",
-          "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
-        },
-        "on-finished": {
-          "version": "2.2.1",
-          "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz"
-        }
-      }
-    },
-    "volos-analytics-common": {
-      "version": "0.2.4",
-      "from": "https://registry.npmjs.org/volos-analytics-common/-/volos-analytics-common-0.2.4.tgz",
-      "resolved": "https://registry.npmjs.org/volos-analytics-common/-/volos-analytics-common-0.2.4.tgz"
-    },
-    "volos-cache-common": {
-      "version": "0.10.5",
-      "from": "https://registry.npmjs.org/volos-cache-common/-/volos-cache-common-0.10.5.tgz",
-      "resolved": "https://registry.npmjs.org/volos-cache-common/-/volos-cache-common-0.10.5.tgz",
-      "dependencies": {
-        "underscore": {
-          "version": "1.6.0",
-          "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
-        }
-      }
-    },
-    "volos-cache-memory": {
-      "version": "0.10.1",
-      "from": "https://registry.npmjs.org/volos-cache-memory/-/volos-cache-memory-0.10.1.tgz",
-      "resolved": "https://registry.npmjs.org/volos-cache-memory/-/volos-cache-memory-0.10.1.tgz"
-    },
-    "volos-quota-apigee": {
-      "version": "0.13.1",
-      "from": "https://registry.npmjs.org/volos-quota-apigee/-/volos-quota-apigee-0.13.1.tgz",
-      "resolved": "https://registry.npmjs.org/volos-quota-apigee/-/volos-quota-apigee-0.13.1.tgz",
-      "dependencies": {
-        "semver": {
-          "version": "3.0.1",
-          "from": "https://registry.npmjs.org/semver/-/semver-3.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-3.0.1.tgz"
-        }
-      }
-    },
-    "volos-quota-common": {
-      "version": "0.11.3",
-      "from": "https://registry.npmjs.org/volos-quota-common/-/volos-quota-common-0.11.3.tgz",
-      "resolved": "https://registry.npmjs.org/volos-quota-common/-/volos-quota-common-0.11.3.tgz",
-      "dependencies": {
-        "underscore": {
-          "version": "1.6.0",
-          "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
-        }
-      }
-    },
-    "volos-quota-memory": {
-      "version": "0.11.1",
-      "from": "https://registry.npmjs.org/volos-quota-memory/-/volos-quota-memory-0.11.1.tgz",
-      "resolved": "https://registry.npmjs.org/volos-quota-memory/-/volos-quota-memory-0.11.1.tgz"
-    },
-    "volos-spikearrest-common": {
-      "version": "0.10.3",
-      "from": "https://registry.npmjs.org/volos-spikearrest-common/-/volos-spikearrest-common-0.10.3.tgz",
-      "resolved": "https://registry.npmjs.org/volos-spikearrest-common/-/volos-spikearrest-common-0.10.3.tgz",
-      "dependencies": {
-        "underscore": {
-          "version": "1.6.0",
-          "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
-        }
-      }
-    },
-    "volos-spikearrest-memory": {
-      "version": "0.10.1",
-      "from": "https://registry.npmjs.org/volos-spikearrest-memory/-/volos-spikearrest-memory-0.10.1.tgz",
-      "resolved": "https://registry.npmjs.org/volos-spikearrest-memory/-/volos-spikearrest-memory-0.10.1.tgz"
-    },
-    "which": {
-      "version": "1.1.2",
-      "from": "https://registry.npmjs.org/which/-/which-1.1.2.tgz",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.1.2.tgz"
-    },
-    "winston": {
-      "version": "2.2.0",
-      "from": "https://registry.npmjs.org/winston/-/winston-2.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.2.0.tgz",
-      "dependencies": {
-        "async": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz"
-        }
-      }
-    },
-    "winston-daily-rotate-file": {
-      "version": "1.0.1",
-      "from": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-1.0.1.tgz",
-      "dependencies": {
-        "async": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz"
-        },
-        "winston": {
-          "version": "2.1.1",
-          "from": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz"
-        }
-      }
-    },
-    "wrappy": {
-      "version": "1.0.1",
-      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-    },
     "xml2js": {
-      "version": "0.4.16",
-      "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.16.tgz",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.16.tgz"
-    },
-    "xmlbuilder": {
-      "version": "4.2.1",
-      "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+      "version": "0.4.17",
+      "from": "xml2js@>=0.4.16 <0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
       "dependencies": {
-        "lodash": {
-          "version": "4.11.0",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-4.11.0.tgz",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.11.0.tgz"
+        "sax": {
+          "version": "1.2.1",
+          "from": "sax@>=0.6.0",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz"
+        },
+        "xmlbuilder": {
+          "version": "4.2.1",
+          "from": "xmlbuilder@>=4.1.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "4.14.0",
+              "from": "lodash@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.0.tgz"
+            }
+          }
         }
       }
-    },
-    "xtend": {
-      "version": "4.0.1",
-      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-    },
-    "yallist": {
-      "version": "2.0.0",
-      "from": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edgemicro",
-  "version": "2.0.10",
+  "version": "2.0.11-pcf.0",
   "description": "Configurator and Launcher for Apigee Edge Microgateway",
   "author": "shawnfeldman",
   "main": "index.js",
@@ -24,7 +24,7 @@
     "lodash": "^3.9.3",
     "log-symbols": "^1.0.2",
     "microgateway-config": "^2.0.9",
-    "microgateway-core": "^2.0.15",
+    "microgateway-core": "apigee/microgateway-core#pcf",
     "microgateway-edgeauth": "^1.0.2",
     "microgateway-plugins": "^2.0.4",
     "pem": "^1.8.1",
@@ -51,7 +51,7 @@
     }
   },
   "scripts": {
-    "start": "./cli/edgemicro start",
+    "start": "./startmicro",
     "package": "node cli/package.js",
     "test": "mocha --timeout 7000 tests"
   },

--- a/startmicro
+++ b/startmicro
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+regex="([^/]+)-(.+)-cache-config.yaml"
+
+for file in ~/.edgemicro/*; do
+    if [[ $file =~ $regex ]]; then
+        org=${BASH_REMATCH[1]}
+        env=${BASH_REMATCH[2]}
+        key=$(grep '\bkey:' $file | cut -d':' -f2)
+        secret=$(grep '\bsecret:' $file | cut -d':' -f2)
+        break
+    fi
+done
+
+if [[ -z "$org" ]]; then
+    echo ERROR: {org}-{env}-cache-config.yaml not found in ~/.edgemicro
+    exit 1
+fi
+
+NODE_TLS_REJECT_UNAUTHORIZED=0 ./cli/edgemicro start -o $org -e $env -k $key -s $secret

--- a/startmicro
+++ b/startmicro
@@ -1,14 +1,24 @@
 #!/usr/bin/env bash
 
-regex="([^/]+)-(.+)-cache-config.yaml"
+regex="([^\/]+)-([^-]+)-cache-config.yaml"
+node_yaml='(() => {
+var yaml = require("js-yaml");
+var fs   = require("fs");
+var doc  = yaml.safeLoad(fs.readFileSync(process.argv[1], "utf8"));
+return `-k ${doc.analytics.key} -s ${doc.analytics.secret}`;
+})()'
 
 for file in ~/.edgemicro/*; do
     if [[ $file =~ $regex ]]; then
         org=${BASH_REMATCH[1]}
         env=${BASH_REMATCH[2]}
-        key=$(grep '\bkey:' $file | cut -d':' -f2)
-        secret=$(grep '\bsecret:' $file | cut -d':' -f2)
-        break
+        key_secret=$(node -p "$node_yaml" "$file")
+        if [[ $? -eq 0 ]]; then
+            break
+        else
+            echo ERROR: cannot read key/secret from $file
+            exit 1
+        fi
     fi
 done
 
@@ -17,4 +27,6 @@ if [[ -z "$org" ]]; then
     exit 1
 fi
 
-NODE_TLS_REJECT_UNAUTHORIZED=0 ./cli/edgemicro start -o $org -e $env -k $key -s $secret
+args="-o $org -e $env $key_secret"
+#echo $args
+NODE_TLS_REJECT_UNAUTHORIZED=0 ./cli/edgemicro start $args


### PR DESCRIPTION
Three related commits in
- microgateway
- microgateway-config
- microgateway-core

activating Cloud-Foundry-related functionality via configurable names

Also includes a new start script that actually will start microgateway using cache-config instead of showing startup options.
