### PR TITLE
localproxy mode for edgemicro

### DIFF
--- a/cli/cmd.js
+++ b/cli/cmd.js
@@ -7,7 +7,6 @@ const run = require('./lib/gateway')();
 const keyGenerator = require('./lib/key-gen')();
 const prompt = require('cli-prompt');
 const cluster = require('cluster')
-const init = require('./lib/init')
 
 const setup = function setup() {
   commander
@@ -34,18 +33,11 @@ const setup = function setup() {
       promptForPassword(options,(options)=>{
         if (!options.password) { return options.error('password is required'); }
         configure.configure(options, () => {
+          process.exit(0);
         });
       })
     });
 
- commander
-    .command('init')
-    .description('initialize default.yaml into home dir')
-    .action((options) => {
-      init((err,location)=>{
-        console.log("config initialized to %s",location)
-      })
-    });
 
   commander
     .command('verify')
@@ -73,6 +65,9 @@ const setup = function setup() {
     .option('-c, --cluster', 'will cluster the server')
     .option('-p, --processes <processes>', 'number of processes to start, defaults to # of cores')
     .option('-d, --pluginDir <pluginDir>','absolute path to plugin directory')
+    .option('-a, --app_name <app_name>','local app name')
+    .option('-b, --app_path <app_path>','local app path')
+    .option('-t, --target_url <target_url>','local target url')
     .description('start the gateway based on configuration')
     .action((options)=>{
       options.error = optionError;

--- a/cli/lib/gateway.js
+++ b/cli/lib/gateway.js
@@ -22,9 +22,11 @@ Gateway.prototype.start = function start(options, cb) {
   const keys = { key: options.key, secret: options.secret };
   const args = { target: cache, keys: keys,pluginDir:options.pluginDir };
   const that = this;
-
+  const localproxy;
+  if(options.app_name && options.app_path && options.target_url)
+    localproxy = {name:options.app_name , path:options.app_path, target_url:options.target_url}
   if (cluster.isMaster) {
-    edgeconfig.get({ source: source, keys: keys, localproxy: {name:options.app_name , path:options.app_path, target_url:options.target_url} }, function (err, config) {      
+    edgeconfig.get({ source: source, keys: keys, localproxy: localproxy }, function (err, config) {      
       if(options.port){
         config.edgemicro.port = parseInt(options.port);
       }

--- a/cli/lib/gateway.js
+++ b/cli/lib/gateway.js
@@ -24,7 +24,7 @@ Gateway.prototype.start = function start(options, cb) {
   const args = { target: cache, keys: keys,pluginDir:options.pluginDir };
   const that = this;
   if (cluster.isMaster) {
-    edgeconfig.get({ source: source, keys: keys }, function (err, config) {
+    edgeconfig.get({ source: source, keys: keys, localproxy: {name:options.app_name , path:options.app_path, target_url:options.target_url} }, function (err, config) {
       if (err) {
         const exists = fs.existsSync(cache);
         console.error("failed to retieve config from gateway. continuing, will try cached copy..");


### PR DESCRIPTION
I added localproxy support for micro sometime back - so it can run without having to pull config from edge. this was helpful when embedding microgateway as a sidecar container when deploying applications in containers [specifically w/ kubernetes], 
do you think this will be useful for mainstream micro usecases?
This is supposed to work with this PR - https://github.com/apigee/microgateway-config/pull/6
