### PR TITLE
Need to be able to specify number of processes cluster should use with the -p or --processes flag.

### DIFF
--- a/cli/lib/gateway.js
+++ b/cli/lib/gateway.js
@@ -63,6 +63,12 @@ Gateway.prototype.start =  (options) => {
     var opt = {};
     opt.args = [JSON.stringify(args)];
     opt.timeout = 10;
+    
+    //Let reload cluster know how many processes to use if the user doesn't want the default
+    if(options.processes) {
+      opt.workers = Number(options.processes);
+    }
+
     var mgCluster = reloadCluster(path.join(__dirname, 'start-agent.js'), opt);
 
     var server = net.createServer();


### PR DESCRIPTION
The `-p` flag doesn't work as expected currently. This is a fix for that.