### PR TITLE
Formatting the url before handing it off to the cert lib.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ tmp-*
 default.yaml.bak
 *-*-*config.yaml
 test-token.txt
+env.sh

--- a/cli/lib/cert-lib.js
+++ b/cli/lib/cert-lib.js
@@ -393,7 +393,7 @@ function isApigeeError(err, code) {
 
 function getPublicKey(organization, environment, authUri,cb) {
 
-  const uri = util.format(authUri + '/publicKey', organization, environment);
+  const uri = authUri + '/publicKey';
   request({
     uri: uri,
   }, function(err, res) {

--- a/cli/lib/cert.js
+++ b/cli/lib/cert.js
@@ -44,8 +44,6 @@ Cert.prototype.installCert = function(options, cb) {
 
 Cert.prototype.checkCert = function(options, cb) {
 
-
-
   assert(options.org,"org is required");
   assert(options.env,"env is required")
 
@@ -53,6 +51,16 @@ Cert.prototype.checkCert = function(options, cb) {
   assert(options.password,"password is required")
 
   const config = edgeconfig.load({ source: configLocations.getSourcePath(options.org, options.env) });
+  if (options.url) {
+    if (options.url.indexOf('://') === -1) {
+      options.url = 'https://' + options.url;
+    }
+    config.edge_config.authUri = options.url + '/edgemicro-auth';
+  } else {
+    var newAuthURI = util.format(config.edge_config.authUri, options.org, options.env);
+    config.edge_config.authUri = newAuthURI;
+  }
+
   cert(config).checkCertWithPassword(options, (err, res) => {
     if (err) {
       if(cb){
@@ -94,6 +102,15 @@ Cert.prototype.retrievePublicKey = function(options,cb) {
  assert(options.env,"env is required")
 
   const config = edgeconfig.load({ source: configLocations.getSourcePath(options.org, options.env) });
+  if (options.url) {
+    if (options.url.indexOf('://') === -1) {
+      options.url = 'https://' + options.url;
+    }
+    config.edge_config.authUri = options.url + '/edgemicro-auth';
+  } else {
+    var newAuthURI = util.format(config.edge_config.authUri, options.org, options.env);
+    config.edge_config.authUri = newAuthURI;
+  }
   cert(config).retrievePublicKey(options, (err, certificate) => {
     if (err) {
       cb && cb(err);

--- a/cli/lib/configure.js
+++ b/cli/lib/configure.js
@@ -156,8 +156,7 @@ function configureEdgemicroWithCreds(options, cb) {
       agentConfig['edge_config']['jwt_public_key'] = results[0]; // get deploy results
       agentConfig['edge_config'].bootstrap = results[2].bootstrap; // get genkeys results
     } else {
-      agentConfig['edge_config']['jwt_public_key'] =
-        options.url ? authUri + '/publicKey' : util.format(authUri + '/publicKey', options.org, options.env);
+      agentConfig['edge_config']['jwt_public_key'] = authUri + '/publicKey';
       agentConfig['edge_config'].bootstrap = results[1].bootstrap;
     }
 

--- a/cli/lib/configure.js
+++ b/cli/lib/configure.js
@@ -50,6 +50,9 @@ Configure.prototype.configure = function configure(options, cb) {
       options.url = 'https://' + options.url;
     }
     defaultConfig.edge_config.authUri = options.url + '/edgemicro-auth';
+  } else {
+    var newAuthURI = util.format(defaultConfig.edge_config.authUri, options.org, options.env);
+    defaultConfig.edge_config.authUri = newAuthURI;
   }
 
   authUri = defaultConfig.edge_config.authUri;


### PR DESCRIPTION
 This fixes issues when trying to configure EM with a custom URL.