### PR TITLE
Updates to remove keys from process args.

### DIFF
--- a/cli/lib/gateway.js
+++ b/cli/lib/gateway.js
@@ -61,6 +61,7 @@ Gateway.prototype.start =  (options) => {
     }
 
     var opt = {};
+    delete args.keys;
     opt.args = [JSON.stringify(args)];
     opt.timeout = 10;
     

--- a/lib/agent-config.js
+++ b/lib/agent-config.js
@@ -20,7 +20,8 @@ const getConfigStart = function getConfigStart(options, cb) {
   fs.exists(options.target, (exists) => {
     if (exists) {
       const config = edgeConfig.load({ source: options.target });
-      startServer(options.keys, options.pluginDir,config, cb);
+      const keys = {key: config.analytics.key, secret: config.analytics.secret};
+      startServer(keys, options.pluginDir,config, cb);
     } else {
       return cb(options.target+" must exist")
     }


### PR DESCRIPTION
Currently we pass API keys to clustered edgemicro processes. This is not desirable because it exposes credentials to anyone that can inspect running processes.

This PR uses a cached config to lookup credentials in processes.