### PR TITLE
Fixing an issue where logging messages weren't being sent to the master process.

### DIFF
--- a/cli/lib/reload-cluster.js
+++ b/cli/lib/reload-cluster.js
@@ -69,7 +69,12 @@ var ReloadCluster = (file, opt) => {
     w._rc_isReplaced = false;
     // whenever worker sends a message, emit it to the channels
     w.on('message', (message) => {
-      emit('message', w, message);
+      if(message.level) {
+        var logHandler = logger[message.level];
+        logHandler(message.msg.trim());
+      } else {
+        emit('message', w, message);
+      }   
     });
     // When a worker exits remove the worker reference from workers array, which holds all the workers
     w.process.on('exit', () => {


### PR DESCRIPTION
I'm not 100% if this is the issue, but when playing with making where we log messages to consistent I was seeing issues with trying to use IPC to pass log messages to the master process. 

This is a prototype PR that outlines how we would propagate log messages from child process to the master process instance of the logger. It depends on another PR in microgateway-core. 