### PR TITLE
Updating reload of config to use port env variable.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -52,6 +52,12 @@ Agent.prototype.start = function start(token,pluginDir, config, cb) {
     if (_isLoopback(config)) {
       return cb && cb(new Error("Error - loopback scenario identified, halting start-up"));
     }
+
+
+    if(process.env.PORT) {
+      config.edgemicro.port = process.env.PORT;
+    }
+
     this.gatewayServer = gateway(pluginDir,config);
     this.gatewayServer.start((err) => {
       err && console.error(err);


### PR DESCRIPTION
PCF has issues with the zero downtime reload feature.

TL;DR

When PCF allows EM to execute a reload it doesn't pick up environment variables that it needs to run. Like port. This causes EM to be marked unhealthy and restart.

This fix accounts for that. @kenigeer As someone with more PCF experience are there other env variables I should account for and override in the config?

-Matt