### PR TITLE
Updating to not need an existing .edgemicro directory for config.

### DIFF
--- a/cli/lib/configure.js
+++ b/cli/lib/configure.js
@@ -28,11 +28,11 @@ module.exports = function () {
 }
 
 Configure.prototype.configure = function configure(options, cb) {
-  if (!fs.existsSync(configLocations.getDefaultPath())) {
+  if (!fs.existsSync(configLocations.getDefaultPath(options.configDir))) {
     console.error("Missing %s, Please run 'edgemicro init'",configLocations.getDefaultPath())
     return cb("Please call edgemicro init first")
   }
-  defaultConfig = edgeconfig.load({ source: configLocations.getDefaultPath() });
+  defaultConfig = edgeconfig.load({ source: configLocations.getDefaultPath(options.configDir) });
   addEnvVars(defaultConfig);
   deployAuth = deployAuthLib(defaultConfig.edge_config, null)
   managementUri = defaultConfig.edge_config.managementUri;
@@ -75,7 +75,7 @@ Configure.prototype.configure = function configure(options, cb) {
   var configFileDirectory = options.configDir || configLocations.homeDir; 
   //console.log('init config');
   edgeconfig.init({
-    source: configLocations.getDefaultPath(),
+    source: configLocations.getDefaultPath(options.configDir),
     targetDir: configFileDirectory,
     targetFile: targetFile,
     overwrite: true

--- a/config/locations.js
+++ b/config/locations.js
@@ -15,8 +15,12 @@ module.exports = {
   getInitPath: function(opts){
     return  path.join(configDir,defaultFile);
   },
-  getDefaultPath: function(){
-    return  path.join(this.homeDir,defaultFile);
+  getDefaultPath: function(customConfigDir){
+    if(customConfigDir) {
+      return path.join(customConfigDir, defaultFile);
+    } else {
+      return  path.join(this.homeDir,defaultFile);
+    }
   },
   defaultFile: defaultFile,
   getSourcePath: function getSource(org, env, customConfigDir){


### PR DESCRIPTION
Right now the custom configuration directory depends on the existence of an `.edgemicro` directory to work. This remedies that.