### PR TITLE
Set a custom proxyName for edgemicro-auth proxy

### DIFF
--- a/cli/cmd.js
+++ b/cli/cmd.js
@@ -29,6 +29,7 @@ const setup = function setup() {
     .option('-r, --url <url>', 'organization\'s custom API URL (https://api.example.com)')
     .option('-d, --debug', 'execute with debug output')
     .option('-c, --configDir <configDir>', 'Set the directory where configs are written.')
+    .option('-x, --proxyName <proxyName>', 'Set the custom proxy name for edgemicro-auth')
     .action((options) => {
       options.error = optionError;
       if (!options.username) { return options.error('username is required'); }

--- a/cli/lib/configure.js
+++ b/cli/lib/configure.js
@@ -43,13 +43,16 @@ Configure.prototype.configure = function configure(options, cb) {
   assert(options.org, 'org is required');
   assert(options.env, 'env is required');
 
-  options.proxyName = 'edgemicro-auth';
+  if(!options.proxyName) {
+    options.proxyName = 'edgemicro-auth';
+  }
+  
 
   if (options.url) {
     if (options.url.indexOf('://') === -1) {
       options.url = 'https://' + options.url;
     }
-    defaultConfig.edge_config.authUri = options.url + '/edgemicro-auth';
+    defaultConfig.edge_config.authUri = options.url + '/' + options.proxyName;
   } else {
     var newAuthURI = util.format(defaultConfig.edge_config.authUri, options.org, options.env);
     defaultConfig.edge_config.authUri = newAuthURI;


### PR DESCRIPTION
As a user I may change the name of my edgemicro-auth proxy. This fixes that. 