### PR TITLE
Resolves EM-199 - error when trying to execute "edgemicro private configure" command

### DIFF
--- a/cli/lib/cert-lib.js
+++ b/cli/lib/cert-lib.js
@@ -73,8 +73,8 @@ CertLogic.prototype.checkPrivateCert = function(options, callback) {
     request({
       uri: uri,
       auth: generateCredentialsObject(options)
-    }, function(err, res, body) {
-      err = translateError(err, res, body);
+    }, function(err, res) {
+      err = translateError(err, res);
       if (err) {
         return callback(err);
       }

--- a/cli/lib/cert-lib.js
+++ b/cli/lib/cert-lib.js
@@ -51,12 +51,12 @@ CertLogic.prototype.retrievePublicKeyPrivate = function( callback) {
 }
 
 CertLogic.prototype.checkCertWithPassword = function(options, callback) {
-  var uri = util.format('%s/v1/organizations/%s/environments/%s/keyvaluemaps/%s', 
+  var uri = util.format('%s/v1/organizations/%s/environments/%s/keyvaluemaps/%s',
     this.managementUri, options.org, options.env, this.vaultName);
   request({
     uri: uri,
     auth: generateCredentialsObject(options)
-  }, function(err, res, body) {
+  }, function(err, res) {
     err = translateError(err, res);
     if (err) {
       return callback(err);
@@ -67,16 +67,14 @@ CertLogic.prototype.checkCertWithPassword = function(options, callback) {
 
 CertLogic.prototype.checkPrivateCert = function(options, callback) {
 
-  
-    var uri = util.format('%s/v1/organizations/%s/environments/%s/keyvaluemaps/%s/entries',
+    var uri = util.format('%s/v1/organizations/%s/environments/%s/keyvaluemaps/%s/entries/private_key',
         this.managementUri, options.org, options.env, this.vaultName);
 
-    
     request({
       uri: uri,
       auth: generateCredentialsObject(options)
-    }, function(err, res) {
-      err = translateError(err, res);
+    }, function(err, res, body) {
+      err = translateError(err, res, body);
       if (err) {
         return callback(err);
       }
@@ -84,7 +82,7 @@ CertLogic.prototype.checkPrivateCert = function(options, callback) {
       callback(null, res.body);
 
     });
-  
+
 }
 
 CertLogic.prototype.installPrivateCert = function(options, callback) {
@@ -111,7 +109,7 @@ CertLogic.prototype.installPrivateCert = function(options, callback) {
             deleteVault(generateCredentialsObject(options), managementUri, options.org, options.env, vaultName, cb);
           },
           function(cb) {
-            console.log('creating vault');
+            console.log('creating KVM');
             console.log('adding private_key');
             console.log('adding public_key');
             var entries = [
@@ -172,7 +170,7 @@ CertLogic.prototype.installCertWithPassword = function(options, callback) {
             deleteVault(generateCredentialsObject(options), managementUri, options.org, options.env, vaultName, cb);
           },
           function(cb) {
-            console.log('creating vault');
+            console.log('creating KVM');
             console.log('adding private_key');
             console.log('adding public_key');
             var entries = [
@@ -195,7 +193,7 @@ CertLogic.prototype.installCertWithPassword = function(options, callback) {
               {
                 'name': 'public_key1_kid',
                 'value': '1'
-              }              
+              }
             ]
             createVault(generateCredentialsObject(options), managementUri, options.org, options.env, vaultName, entries, cb);
           }
@@ -207,7 +205,7 @@ CertLogic.prototype.installCertWithPassword = function(options, callback) {
             callback(null, publicKey);
           }
         }
-        );    
+        );
       });
     });
 }
@@ -318,7 +316,7 @@ CertLogic.prototype.deleteCertWithPassword = function deleteCertWithPassword(opt
     if (err) {
       cb(err);
     } else {
-      cb(null,'Vault deleted!');
+      cb(null,'KVM deleted!');
     }
   });
 };
@@ -343,14 +341,14 @@ function createCert(cb) {
 }
 
 function deleteVault(credentials, managementUri, organization, environment, vaultName, cb) {
-  console.log('deleting vault');
-    
+  console.log('deleting KVM');
+
   var uri = util.format('%s/v1/organizations/%s/environments/%s/keyvaluemaps/%s', managementUri, organization, environment, vaultName);
-    
+
   request({
     uri: uri,
     method: 'DELETE',
-    auth: credentials 
+    auth: credentials
   }, function(err, res) {
     err = translateError(err, res);
     if (isApigeeError(err, ERR_STORE_MISSING)) {
@@ -360,19 +358,19 @@ function deleteVault(credentials, managementUri, organization, environment, vaul
     cb(err, res);
   });
 
-  
-  
+
+
 }
 
 function createVault(credentials, managementUri, organization, environment, vaultName, entries, cb) {
 
-  var storageOpts = { 
+  var storageOpts = {
     name: vaultName,
     encrypted: 'true',
     entry: entries
   }
   var uri = util.format('%s/v1/organizations/%s/environments/%s/keyvaluemaps', managementUri, organization, environment);
-  
+
   request({
     uri: uri,
     method: 'POST',
@@ -391,7 +389,6 @@ function createVault(credentials, managementUri, organization, environment, vaul
 
 function translateError(err, res) {
   if (!err && res.statusCode >= 400) {
-
     const msg = 'cannot ' + res.request.method + ' ' + url.format(res.request.uri) + ' (' + res.statusCode + ')';
     err = new Error(msg);
     err.text = res.body;

--- a/cli/lib/configure.js
+++ b/cli/lib/configure.js
@@ -48,7 +48,7 @@ Configure.prototype.configure = function configure(options, cb) {
   if(!options.proxyName) {
     options.proxyName = 'edgemicro-auth';
   }
-  
+
 
   if (options.url) {
     if (options.url.indexOf('://') === -1) {
@@ -76,8 +76,8 @@ Configure.prototype.configure = function configure(options, cb) {
     fs.unlinkSync(targetPath);
     //console.log('deleted ' + targetPath);
   }
-  
-  var configFileDirectory = options.configDir || configLocations.homeDir; 
+
+  var configFileDirectory = options.configDir || configLocations.homeDir;
   //console.log('init config');
   edgeconfig.init({
     source: configLocations.getDefaultPath(options.configDir),
@@ -123,13 +123,13 @@ function configureEdgemicroWithCreds(options, cb) {
   tasks.push(
     function (callback) {
       setTimeout(() => {
-        console.log('checking org for existing vault');
+        console.log('checking org for existing KVM');
         cert.checkCertWithPassword(options, function (err, certs) {
           if (err) {
-            console.log('error checking for cert. Installing new cert.')
+            console.log('error checking for cert. Installing new cert.');
             cert.installCertWithPassword(options, callback);
           } else {
-            console.log('vault already exists in your org');
+            console.log('KVM already exists in your org');
             cert.retrievePublicKey(options, callback);
           }
         });
@@ -227,4 +227,3 @@ function printError(err) {
     console.log(err);
   }
 }
-

--- a/cli/lib/private.js
+++ b/cli/lib/private.js
@@ -222,8 +222,6 @@ Private.prototype.configureEdgeMicroInternalProxy = function configureEdgeMicroI
   })
 }
 
-
-
 // checks deployments, deploys proxies as necessary, checks/installs certs, generates keys
 Private.prototype.configureEdgemicroWithCreds = function configureEdgemicroWithCreds(options, cb) {
   const that = this;
@@ -263,12 +261,13 @@ Private.prototype.configureEdgemicroWithCreds = function configureEdgemicroWithC
   }
 
   tasks.push(function (callback) {
-    console.log('checking org for existing vault');
+    console.log('checking org for existing KVM');
     that.cert.checkPrivateCert(options, function (err, certs) {
-      if (err) {
+      if (err){
+        console.log('error checking for cert. Installing new cert.');
         that.cert.installPrivateCert(options, callback);
       } else {
-        console.log('vault already exists in your org');
+        console.log('KVM already exists in your org');
         that.cert.retrievePublicKeyPrivate(callback);
       }
     });
@@ -316,7 +315,7 @@ Private.prototype.configureEdgemicroWithCreds = function configureEdgemicroWithC
 
         agentConfig['analytics']['uri'] = bootstrapUri.replace('bootstrap', 'axpublisher');
       }
-      
+
       console.log();
       console.log('saving configuration information to:', agentConfigPath);
       edgeconfig.save(agentConfig, agentConfigPath);
@@ -333,8 +332,6 @@ Private.prototype.configureEdgemicroWithCreds = function configureEdgemicroWithC
 
     });
 };
-
-
 
 Private.prototype.generateKeysWithPassword = function generateKeysWithPassword(options, cb) {
 
@@ -443,4 +440,3 @@ function optionError(message) {
   console.error(message);
   this.help();
 }
-

--- a/cli/lib/private.js
+++ b/cli/lib/private.js
@@ -263,7 +263,7 @@ Private.prototype.configureEdgemicroWithCreds = function configureEdgemicroWithC
   tasks.push(function (callback) {
     console.log('checking org for existing KVM');
     that.cert.checkPrivateCert(options, function (err, certs) {
-      if (err){
+      if (err) {
         console.log('error checking for cert. Installing new cert.');
         that.cert.installPrivateCert(options, callback);
       } else {


### PR DESCRIPTION
This commit resolves the following error when executing "edgemicro private configure"

{ code: 'keyvaluemap.service.keyvaluemap_already_exist', message: 'KeyValueMap microgateway already exists', contexts: [] }

I also changes some of the console log statements from "vault" to "KVM."
