### PR TITLE
Changing proxy name to reflect the service name

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -218,13 +218,13 @@ Use the svc parameter to pass your service file. See the helloworld sample below
 
 
 ### Helloworld sample
-[here](/docs/helloworld.md)
+[here](./docs/helloworld.md)
 
 ### Automatic Sidecar Injection
-[here](/docs/automatic_sidecar.md)
+[here](./docs/automatic_sidecar.md)
 
 ### Running Bookinfo sample
-[here](/docs/bookinfo.md)
+[here](./docs/bookinfo.md)
 
 ### Understanding edgemicroctl
 

--- a/kubernetes/docker/edgemicro/entrypoint.sh
+++ b/kubernetes/docker/edgemicro/entrypoint.sh
@@ -7,10 +7,10 @@ exec 2>&1
 
 echo "Log Location should be: [ $LOG_LOCATION ]"
 
-SERVICE_NAME=`echo "${SERVICE_NAME}" | tr '[a-z]' '[A-Z]'`
-SERVICE_PORT_NAME=${SERVICE_NAME}_SERVICE_PORT
+SERVICE_NAME_UPPERCASE=`echo "${SERVICE_NAME}" | tr '[a-z]' '[A-Z]'`
+SERVICE_PORT_NAME=${SERVICE_NAME_UPPERCASE}_SERVICE_PORT
 SERVICE_PORT=${!SERVICE_PORT_NAME}
-proxy_name=edgemicro_$POD_NAME
+proxy_name=edgemicro_${SERVICE_NAME}_service
 product_name=$proxy_name-product
 
 
@@ -45,12 +45,12 @@ fi
 my_handler() {
   echo "my_handler" >> /tmp/entrypoint.log
   su - apigee -m -c "cd /opt/apigee && edgemicro stop"
-  if [[ ${EDGEMICRO_DECORATOR} != "" ]]; then
+  #if [[ ${EDGEMICRO_DECORATOR} != "" ]]; then
       #Attempt deleting the proxy here
-      curl -v -X DELETE -u $EDGEMICRO_ADMINEMAIL:$EDGEMICRO_ADMINPASSWORD -H "Content-Type:application/x-www-form-urlencoded" ${EDGEMICRO_MGMTURL}/v1/organizations/${EDGEMICRO_ORG}/apiproducts/${product_name}
-      curl -v -X DELETE -u $EDGEMICRO_ADMINEMAIL:$EDGEMICRO_ADMINPASSWORD -H "Content-Type:application/x-www-form-urlencoded" ${EDGEMICRO_MGMTURL}/v1/organizations/${EDGEMICRO_ORG}/environments/${EDGEMICRO_ENV}/apis/${proxy_name}/revisions/1/deployments
-      curl -v -X DELETE -u $EDGEMICRO_ADMINEMAIL:$EDGEMICRO_ADMINPASSWORD -H "Content-Type:application/x-www-form-urlencoded" ${EDGEMICRO_MGMTURL}/v1/organizations/${EDGEMICRO_ORG}/apis/${proxy_name}
-  fi
+      #curl -v -X DELETE -u $EDGEMICRO_ADMINEMAIL:$EDGEMICRO_ADMINPASSWORD -H "Content-Type:application/x-www-form-urlencoded" ${EDGEMICRO_MGMTURL}/v1/organizations/${EDGEMICRO_ORG}/apiproducts/${product_name}
+      #curl -v -X DELETE -u $EDGEMICRO_ADMINEMAIL:$EDGEMICRO_ADMINPASSWORD -H "Content-Type:application/x-www-form-urlencoded" ${EDGEMICRO_MGMTURL}/v1/organizations/${EDGEMICRO_ORG}/environments/${EDGEMICRO_ENV}/apis/${proxy_name}/revisions/1/deployments
+      #curl -v -X DELETE -u $EDGEMICRO_ADMINEMAIL:$EDGEMICRO_ADMINPASSWORD -H "Content-Type:application/x-www-form-urlencoded" ${EDGEMICRO_MGMTURL}/v1/organizations/${EDGEMICRO_ORG}/apis/${proxy_name}
+  #fi
   #edgemicro stop
 }
 
@@ -58,11 +58,11 @@ my_handler() {
 term_handler() {
   echo "term_handler" >> /tmp/entrypoint.log
   su - apigee -m -c "cd /opt/apigee && edgemicro stop"
-  if [[ ${EDGEMICRO_DECORATOR} != "" ]]; then
-      curl -v -X DELETE -u $EDGEMICRO_ADMINEMAIL:$EDGEMICRO_ADMINPASSWORD -H "Content-Type:application/x-www-form-urlencoded" ${EDGEMICRO_MGMTURL}/v1/organizations/${EDGEMICRO_ORG}/apiproducts/${product_name}
-      curl -v -X DELETE -u $EDGEMICRO_ADMINEMAIL:$EDGEMICRO_ADMINPASSWORD -H "Content-Type:application/x-www-form-urlencoded" ${EDGEMICRO_MGMTURL}/v1/organizations/${EDGEMICRO_ORG}/environments/${EDGEMICRO_ENV}/apis/${proxy_name}/revisions/1/deployments
-      curl -v -X DELETE -u $EDGEMICRO_ADMINEMAIL:$EDGEMICRO_ADMINPASSWORD -H "Content-Type:application/x-www-form-urlencoded" ${EDGEMICRO_MGMTURL}/v1/organizations/${EDGEMICRO_ORG}/apis/${proxy_name}
-  fi
+  #if [[ ${EDGEMICRO_DECORATOR} != "" ]]; then
+      #curl -v -X DELETE -u $EDGEMICRO_ADMINEMAIL:$EDGEMICRO_ADMINPASSWORD -H "Content-Type:application/x-www-form-urlencoded" ${EDGEMICRO_MGMTURL}/v1/organizations/${EDGEMICRO_ORG}/apiproducts/${product_name}
+      #curl -v -X DELETE -u $EDGEMICRO_ADMINEMAIL:$EDGEMICRO_ADMINPASSWORD -H "Content-Type:application/x-www-form-urlencoded" ${EDGEMICRO_MGMTURL}/v1/organizations/${EDGEMICRO_ORG}/environments/${EDGEMICRO_ENV}/apis/${proxy_name}/revisions/1/deployments
+      #curl -v -X DELETE -u $EDGEMICRO_ADMINEMAIL:$EDGEMICRO_ADMINPASSWORD -H "Content-Type:application/x-www-form-urlencoded" ${EDGEMICRO_MGMTURL}/v1/organizations/${EDGEMICRO_ORG}/apis/${proxy_name}
+  #fi
   #edgemicro stop
   exit 143; # 128 + 15 -- SIGTERM
 }

--- a/kubernetes/docker/edgemicro_apigee_setup/setup.sh
+++ b/kubernetes/docker/edgemicro_apigee_setup/setup.sh
@@ -15,9 +15,9 @@ set -o pipefail
 #echo $POD_NAME >> /tmp/test.txt
 #echo $POD_NAMESPACE >> /tmp/test.txt
 #echo $INSTANCE_IP >> /tmp/test.txt
-SERVICE_NAME=`echo "${SERVICE_NAME}" | tr '[a-z]' '[A-Z]'`
+SERVICE_NAME_UPPERCASE=`echo "${SERVICE_NAME}" | tr '[a-z]' '[A-Z]'`
 #echo $SERVICE_NAME >> /tmp/test.txt
-SERVICE_PORT_NAME=${SERVICE_NAME}_SERVICE_PORT
+SERVICE_PORT_NAME=${SERVICE_NAME_UPPERCASE}_SERVICE_PORT
 SERVICE_PORT=${!SERVICE_PORT_NAME}
 #echo $SERVICE_PORT >> /tmp/test.txt
 
@@ -27,9 +27,9 @@ APIGEE_ADMINPW=$EDGEMICRO_ADMINPASSWORD
 mgmt_api=$EDGEMICRO_MGMTURL
 org=$EDGEMICRO_ORG
 env_name=$EDGEMICRO_ENV
-proxy_name=edgemicro_$POD_NAME
+proxy_name=edgemicro_${SERVICE_NAME}_service
 target_port=$SERVICE_PORT
-base_path=$POD_NAME
+base_path=$SERVICE_NAME
 
 
 curl -X POST -u $APIGEE_ADMIN_EMAIL:$APIGEE_ADMINPW -H "Content-Type:application/json" ${mgmt_api}/v1/organizations/${org}/apis  -d "{\"name\" : \"$proxy_name\"}" 


### PR DESCRIPTION
These changes will help to scale pods created as edgemicro sidecar.
It will create a proxy with name edgemicro_service
and a product with name edgemicro_service-product

How to Test:

kubectl scale deployment helloworld --replicas=2
kubectlkubectl get pods
NAME READY STATUS RESTARTS AGE
helloworld-5bfcfb4d6f-l2kxd 2/2 Running 0 11m
helloworld-5bfcfb4d6f-rldw2 2/2 Running 0 15m

curl ingress-ip -H 'x-api-key: my-api-key'
Delete an old pod
kubectl delete pod helloworld-5bfcfb4d6f-rldw2
curl ingress-ip -H 'x-api-key: my-api-key'