### PR TITLE
Adding centralized console logging

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ var fs = require('fs');
 var run = require('./cli/lib/gateway')();
 var portastic = require('portastic');
 const os = require('os');
-
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
 const options = {};
 
 options.env = process.env.EDGEMICRO_ENV;
@@ -24,15 +24,15 @@ options.target = process.env.EDGEMICRO_API_TARGET;
 
 options.port = process.env.PORT || 8000;
 
-if (!options.key ) { console.log('key is required'); process.exit(1);}
-if (!options.secret ) { console.log('secret is required'); process.exit(1);}
-if (!options.org ) { console.log('org is required'); process.exit(1);}
-if (!options.env ) { console.log('env is required'); process.exit(1);}
+if (!options.key ) { writeConsoleLog('log','key is required'); process.exit(1);}
+if (!options.secret ) { writeConsoleLog('log','secret is required'); process.exit(1);}
+if (!options.org ) { writeConsoleLog('log','org is required'); process.exit(1);}
+if (!options.env ) { writeConsoleLog('log','env is required'); process.exit(1);}
 if (options.port) {
     portastic.test(options.port)
       .then(function(isAvailable){
         if(!isAvailable) {
-          console.error('port is not available.');
+          writeConsoleLog('error','port is not available.');
           process.exit(1);
         }
      });
@@ -46,19 +46,19 @@ if (options.configUrl) {
   if (parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:") {
     request.get(options.configUrl, function(error, response, body) {
       if (error) {
-        console.error("config file did not download: "+error);
+        writeConsoleLog('error',"config file did not download: "+error);
         process.exit(1);
       }
       try {
         fs.writeFileSync(filePath, body, 'utf8');
         run.start(options);
       } catch (err) {
-        console.error("config file could not be written: " + err);
+        writeConsoleLog('error',"config file could not be written: " + err);
         process.exit(1);
       }
     });
   } else {
-    console.error("url protocol not supported: "+parsedUrl.protocol);
+    writeConsoleLog('error',"url protocol not supported: "+parsedUrl.protocol);
     process.exit(1);
   }
 } else {

--- a/cli/cmd-cert.js
+++ b/cli/cmd-cert.js
@@ -3,6 +3,7 @@
 const commander = require('commander');
 const cert = require('./lib/cert')();
 const prompt = require('cli-prompt');
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
 
 const setup = function setup() {
 
@@ -112,7 +113,7 @@ const setup = function setup() {
 function optionError(caller) {
   return(((obj) => { 
     return((message) => {
-      console.error(message);
+      writeConsoleLog('error',message);
       obj.help();  
     });
    })(caller))

--- a/cli/cmd-private.js
+++ b/cli/cmd-private.js
@@ -6,6 +6,7 @@ const debug = require('debug')('configure');
 const upgradekvm = require('./lib/upgrade-kvm')();
 const upgradeauth = require('./lib/upgrade-edgeauth')();
 const rotatekey = require('./lib/rotate-key')();
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
 
 var prompt = require('cli-prompt');
 
@@ -232,7 +233,7 @@ function promptForPassword(options, cb) {
 function optionError(caller) {
     return(((obj) => { 
       return((message) => {
-        console.error(message);
+        writeConsoleLog('error',message);
         obj.help();  
       });
      })(caller))

--- a/cli/cmd-token.js
+++ b/cli/cmd-token.js
@@ -2,6 +2,7 @@
 
 const commander = require('commander');
 const token = require('./lib/token')();
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
 
 const setup = function setup() {
 
@@ -62,7 +63,7 @@ const setup = function setup() {
 function optionError(caller) {
   return(((obj) => { 
     return((message) => {
-      console.error(message);
+      writeConsoleLog('error',message);
       obj.help();  
     });
    })(caller))

--- a/cli/cmd.js
+++ b/cli/cmd.js
@@ -21,6 +21,7 @@ var foreverOptions = require('../forever.json');
 const forever = require('forever-monitor');
 const pidpath = configLocations.getPIDFilePath();
 var portastic = require('portastic');
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
 
 const setup = function setup() {
     commander
@@ -96,7 +97,7 @@ const setup = function setup() {
         .action((options) => {
             options.configDir = options.configDir || process.env.EDGEMICRO_CONFIG_DIR;
             init(options, (err, location) => {
-                console.log("config initialized to %s", location)
+                writeConsoleLog('log',"config initialized to %s", location)
             })
         });
 
@@ -223,7 +224,7 @@ const setup = function setup() {
                     debug("downloading file...");
                     request.get(options.configUrl, function(error, response, body) {
                         if (error) {
-                            console.error("config file did not download: " + error);
+                            writeConsoleLog('error',"config file did not download: " + error);
                             process.exit(1);
                         }
                         try {
@@ -231,12 +232,12 @@ const setup = function setup() {
                             fs.writeFileSync(filePath, body, 'utf8');
                             run.start(options);
                         } catch (err) {
-                            console.error("config file could not be written: " + err);
+                            writeConsoleLog('error',"config file could not be written: " + err);
                             process.exit(1);
                         }
                     });
                 } else {
-                    console.error("url protocol not supported: " + parsedUrl.protocol);
+                    writeConsoleLog('error',"url protocol not supported: " + parsedUrl.protocol);
                     process.exit(1);
                 }
             } else {
@@ -287,7 +288,7 @@ const setup = function setup() {
                     debug("downloading file...");
                     request.get(options.configUrl, function(error, response, body) {
                         if (error) {
-                            console.error("config file did not download: " + error);
+                            writeConsoleLog('error',"config file did not download: " + error);
                             process.exit(1);
                         }
                         try {
@@ -295,7 +296,7 @@ const setup = function setup() {
                             fs.writeFileSync(filePath, body, 'utf8');
                             run.reload(options);
                         } catch (err) {
-                            console.error("config file could not be written: " + err);
+                            writeConsoleLog('error',"config file could not be written: " + err);
                             process.exit(1);
                         }
                     });
@@ -349,7 +350,7 @@ const setup = function setup() {
                     fs.appendFileSync(pidpath, process.pid + '|');
                     child.start();
                 } catch (piderr) {
-                    console.error('failed to start microgateway: ' + piderr);
+                    writeConsoleLog('error','failed to start microgateway: ' + piderr);
                     process.exit(1);
                 }
             } else {
@@ -361,10 +362,10 @@ const setup = function setup() {
                         });
                         fs.unlinkSync(pidpath);
                     } else {
-                        console.log('pid file not found. please run this command from the folder where microgateway was started.')
+                        writeConsoleLog('log','pid file not found. please run this command from the folder where microgateway was started.')
                     }
                 } catch (piderr) {
-                    console.error('failed to stop microgateway: ' + piderr);
+                    writeConsoleLog('error','failed to stop microgateway: ' + piderr);
                     process.exit(1);
                 }
             }
@@ -590,7 +591,7 @@ const setup = function setup() {
 function optionError(caller) {
     return(((obj) => { 
       return((message) => {
-        console.error(message);
+        writeConsoleLog('error',message);
         obj.help();  
       });
      })(caller))
@@ -615,7 +616,7 @@ function validateUrl(target) {
         url.parse(target, true);
         return true;
     } catch (err) {
-        console.error("Malformed URL: " + err);
+        writeConsoleLog('error',"Malformed URL: " + err);
         return false;
     }
 }

--- a/cli/edgemicro
+++ b/cli/edgemicro
@@ -22,20 +22,22 @@
 
 'use strict';
 var edgemicroVersion = require('../package.json').version;
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
 const version = process.version;
 const ltsVersion = 8;
 const experimental = ["v7", "v9","v11"];
 const latest = 12;
 
+
 //don't print versions when obtaining a token. 
 if (!process.argv.includes("token") && !process.argv.includes("get")) {
-    console.log('current nodejs version is %s', version);
-    console.log('current edgemicro version is %s', edgemicroVersion);    
+    writeConsoleLog('log','current nodejs version is %s', version);
+    writeConsoleLog('log','current edgemicro version is %s', edgemicroVersion);
 }
 
 for (var ver in experimental) {
     if (version.includes(experimental[ver])) {
-        console.log("You are using a version of NodeJS that is not supported");
+        writeConsoleLog('log',"You are using a version of NodeJS that is not supported");
         return;
     }
 }
@@ -43,7 +45,7 @@ for (var ver in experimental) {
 var majorVersion = parseInt(version.split(".")[0].replace("v", ""));
 
 if (majorVersion < ltsVersion || majorVersion > latest) {
-    console.log("You are using a version of NodeJS that is not supported");
+    writeConsoleLog('log',"You are using a version of NodeJS that is not supported");
     return;
 } else {
     require('./cmd')()

--- a/cli/lib/cert-lib.js
+++ b/cli/lib/cert-lib.js
@@ -10,6 +10,7 @@ const pem = require('pem');
 const crypto = require('crypto');
 const async = require('async');
 const debug = require('debug')('cert')
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
 
 const ERR_STORE_EXISTS = 'com.apigee.secure-store.storekey.already.exists';
 const ERR_STORE_MISSING = 'com.apigee.secure-store.securestore_does_not_exist';
@@ -93,7 +94,7 @@ CertLogic.prototype.installPrivateCert = function(options, callback) {
             if (callback) {
                 return callback(err);
             } else {
-                return console.log(err, err.stack);
+                return writeConsoleLog('log',err, err.stack);
             }
         }
 
@@ -111,9 +112,9 @@ CertLogic.prototype.installPrivateCert = function(options, callback) {
                         deleteVault(generateCredentialsObject(options), managementUri, options.org, options.env, vaultName, cb);
                     },
                     function(cb) {
-                        console.log('creating KVM');
-                        console.log('adding private_key');
-                        console.log('adding public_key');
+                        writeConsoleLog('log','creating KVM');
+                        writeConsoleLog('log','adding private_key');
+                        writeConsoleLog('log','adding public_key');
                         var entries = [{
                                 'name': 'private_key',
                                 'value': privateKey
@@ -245,15 +246,15 @@ CertLogic.prototype.generateKeysWithPassword = function generateKeysWithPassword
                     if (res.statusCode >= 200 && res.statusCode <= 202) {
                         if (!res.body.region || !res.body.host) {
                             if (cb) {
-                                cb(console.error('invalid response from region api', regionUrl, res.text));
+                                cb(writeConsoleLog('error','invalid response from region api', regionUrl, res.text));
                             } else {
-                                console.error('invalid response from region api', regionUrl, res.text);
+                                writeConsoleLog('error','invalid response from region api', regionUrl, res.text);
                             }
 
                             return;
                         }
 
-                        console.log('configuring host', res.body.host, 'for region', res.body.region);
+                        writeConsoleLog('log','configuring host', res.body.host, 'for region', res.body.region);
                         var bootstrapUrl = util.format(managementUri, 'bootstrap', options.org, options.env);
                         var parsedUrl = url.parse(bootstrapUrl);
                         parsedUrl.host = res.body.host; // update to regional host
@@ -267,11 +268,11 @@ CertLogic.prototype.generateKeysWithPassword = function generateKeysWithPassword
 
 
                     } else {
-                        cb(console.error('error retrieving region for org', res.statusCode, res.text));
+                        cb(writeConsoleLog('error','error retrieving region for org', res.statusCode, res.text));
                     }
                 });
             } else {
-                cb(console.error('error uploading credentials', res.statusCode, res.text));
+                cb(writeConsoleLog('error','error uploading credentials', res.statusCode, res.text));
             }
         });
     });
@@ -311,7 +312,7 @@ function createCert(cb) {
 }
 
 function deleteVault(credentials, managementUri, organization, environment, vaultName, cb) {
-    console.log('deleting KVM');
+    writeConsoleLog('log','deleting KVM');
 
     var uri = util.format('%s/v1/organizations/%s/environments/%s/keyvaluemaps/%s', managementUri, organization, environment, vaultName);
 
@@ -429,9 +430,9 @@ function uploadCert(options, managementUri, vaultName, privateKey, publicKey, ca
                     deleteVault(generateCredentialsObject(options), managementUri, options.org, options.env, vaultName, cb);
                 },
                 function(cb) {
-                    console.log('creating KVM');
-                    console.log('adding private_key');
-                    console.log('adding public_key');
+                    writeConsoleLog('log','creating KVM');
+                    writeConsoleLog('log','adding private_key');
+                    writeConsoleLog('log','adding public_key');
                     var entries = [{
                             'name': 'private_key',
                             'value': privateKey

--- a/cli/lib/cert.js
+++ b/cli/lib/cert.js
@@ -9,8 +9,9 @@ const _ = require('lodash');
 const async = require('async');
 const util = require('util');
 const configLocations = require('../../config/locations');
-const assert = require('assert')
-
+const assert = require('assert');
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
+edgeconfig.setConsoleLogger(writeConsoleLog);
 
 const Cert = function() {
 };
@@ -36,9 +37,9 @@ Cert.prototype.installCert = function(options, cb) {
   cert(config).installCertWithPassword(options, (err, res) => {
     if (err) {
       if ( cb ) cb(err);
-      return console.error(err, 'failed to update cert');
+      return writeConsoleLog('error',  err, 'failed to update cert');
     }
-    console.log('installed cert');
+    writeConsoleLog('log','installed cert');
     if ( cb ) cb(null,res);
     if ( !cb ) process.exit(0);
   });
@@ -68,9 +69,9 @@ Cert.prototype.checkCert = function(options, cb) {
       if ( cb ) {
         return cb(err);
       }
-      return console.error(err, 'failed to update cert')
+      return writeConsoleLog('error',  err, 'failed to update cert')
     }
-    console.log('checked cert successfully');
+    writeConsoleLog('log','checked cert successfully');
     if ( cb ) cb(null,res);
     if ( !cb ) process.exit(0);
   });
@@ -90,8 +91,8 @@ Cert.prototype.deleteCert = function(options,cb) {
   const config = edgeconfig.load({ source: configLocations.getSourcePath(options.org, options.env) });
 
   cert(config).deleteCertWithPassword(options, function(err, msg) {
-    if ( err ) console.error(err);
-    if ( msg ) console.log(msg);
+    if ( err ) writeConsoleLog('error',  err);
+    if ( msg ) writeConsoleLog('log',msg);
     if ( cb ) cb(err,msg);
     if ( !cb ) process.exit(0);
   })
@@ -116,10 +117,10 @@ Cert.prototype.retrievePublicKey = function(options,cb) {
   cert(config).retrievePublicKey(options, (err, certificate) => {
     if (err) {
       if ( cb ) cb(err);
-      return console.error(err, 'failed to retrieve public key')
+      return writeConsoleLog('error',  err, 'failed to retrieve public key')
     }
-    console.log('succeeded');
-    console.log(certificate);
+    writeConsoleLog('log', 'succeeded');
+    writeConsoleLog('log', certificate);
     if ( cb ) cb(null,certificate);
     if ( !cb ) process.exit(0);
   })
@@ -134,24 +135,24 @@ Cert.prototype.retrievePublicKeyPrivate = function(options) {
   const config = edgeconfig.load({ source: configLocations.getSourcePath(options.org, options.env) });
   cert(config).retrievePublicKeyPrivate((err, certificate) => {
     if (err) {
-      return console.error(err, 'failed to retrieve public key')
+      return writeConsoleLog('error',  err, 'failed to retrieve public key')
     }
-    console.log('succeeded');
-    console.log(certificate);
+    writeConsoleLog('log','succeeded');
+    writeConsoleLog('log', certificate);
   })
 }
 
 /*
 function optionError(message) {
-  console.error(message);
+  writeConsoleLog('error',message);
   this.help();
 }
 
 function printError(err) {
   if (err.response) {
-    console.log(err.response.error);
+    writeConsoleLog('log',err.response.error);
   } else {
-    console.log(err);
+    writeConsoleLog('log',err);
   }
 }
 */

--- a/cli/lib/configure.js
+++ b/cli/lib/configure.js
@@ -9,6 +9,8 @@ const async = require('async')
 const util = require('util')
 const fs = require('fs')
 const assert = require('assert');
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
+edgeconfig.setConsoleLogger(writeConsoleLog);
 const configLocations = require('../../config/locations');
 const BUFFERSIZE    = 10000;
 const BATCHSIZE     = 500;
@@ -31,7 +33,7 @@ module.exports = function () {
 
 Configure.prototype.configure = function configure(options, cb) {    
   if (!fs.existsSync(configLocations.getDefaultPath(options.configDir))) {
-    console.error("Missing %s, Please run 'edgemicro init'",configLocations.getDefaultPath())
+    writeConsoleLog('error',"Missing %s, Please run 'edgemicro init'",configLocations.getDefaultPath())
     return cb("Please call edgemicro init first")
   }
     
@@ -70,17 +72,17 @@ Configure.prototype.configure = function configure(options, cb) {
   const cache = configLocations.getCachePath(options.org, options.env);
   if (fs.existsSync(cache)) {
     fs.unlinkSync(cache);
-    //console.log('deleted ' + cache);
+    //writeConsoleLog('log', 'deleted ' + cache);
   }
 
   const targetPath = configLocations.getSourcePath(options.org, options.env);
   if (fs.existsSync(targetPath)) {
     fs.unlinkSync(targetPath);
-    //console.log('deleted ' + targetPath);
+    //writeConsoleLog('log', 'deleted ' + targetPath);
   }
 
   var configFileDirectory = options.configDir || configLocations.homeDir;
-  //console.log('init config');
+  //writeConsoleLog('log', 'init config');
   edgeconfig.init({
     source: configLocations.getDefaultPath(options.configDir),
     targetDir: configFileDirectory,
@@ -90,13 +92,13 @@ Configure.prototype.configure = function configure(options, cb) {
     options.deployed = false;
     deployAuth.checkDeployedProxies(options, (err, options) => {
       if (err) {
-        console.error(err);
+        writeConsoleLog('error', err);
         if ( cb ) { cb(err) } else process.exit(1);
         return;
       }
       configureEdgemicroWithCreds(options, (err) => {
         if (err) {
-          console.error(err);
+          writeConsoleLog('error', err);
           if ( cb ) { cb(err) } else process.exit(1);
         }
         if ( cb ) { cb(err) } else process.exit(0);
@@ -120,13 +122,13 @@ function configureEdgemicroWithCreds(options, cb) {
   tasks.push(
     function (callback) {
       setTimeout(() => {
-        console.log('checking org for existing KVM');
+        writeConsoleLog('log', 'checking org for existing KVM');
         cert.checkCertWithPassword(options, function (err, certs) {
           if (err) {
-            console.log('error checking for cert. Installing new cert.');
+            writeConsoleLog('log', 'error checking for cert. Installing new cert.');
             cert.installCertWithPassword(options, callback);
           } else {
-            console.log('KVM already exists in your org');
+            writeConsoleLog('log', 'KVM already exists in your org');
             cert.retrievePublicKey(options, callback);
           }
         });
@@ -146,7 +148,7 @@ function configureEdgemicroWithCreds(options, cb) {
     }
     assert(targetFile, 'must have an assigned target file')
 
-    // console.log('updating agent configuration');
+    // writeConsoleLog('log', 'updating agent configuration');
 
     if (err) {
       return cb(err)
@@ -186,30 +188,30 @@ function configureEdgemicroWithCreds(options, cb) {
       agentConfig['analytics']['flushInterval'] = FLUSHINTERVAL;
     }
 
-    console.log();
-    console.log('saving configuration information to:', agentConfigPath);
+    writeConsoleLog('log');
+    writeConsoleLog('log', 'saving configuration information to:', agentConfigPath);
     edgeconfig.save(agentConfig, agentConfigPath); // if it didn't throw, save succeeded
-    console.log();
+    writeConsoleLog('log');
 
     if (options.deployed == true) {  
-      console.log('vault info:\n', results[0]);
+      writeConsoleLog('log', 'vault info:\n', results[0]);
     } else {
-      console.log('vault info:\n', results[1]);
+      writeConsoleLog('log', 'vault info:\n', results[1]);
     }
-    console.log();
+    writeConsoleLog('log');
 
-    console.log(keySecretMessage);
+    writeConsoleLog('log',keySecretMessage);
     const key = results[2] ? results[2].key : results[1].key;
     const secret = results[2] ? results[2].secret : results[1].secret;
     assert(key, 'must have a key');
     assert(secret, 'must have a secret');
-    console.log('  key:', key);
-    console.log('  secret:', secret);
-    console.log();
+    writeConsoleLog('log', '  key:', key);
+    writeConsoleLog('log', '  secret:', secret);
+    writeConsoleLog('log');
     process.env.EDGEMICRO_KEY = key;
     process.env.EDGEMICRO_SECRET = secret;
 
-    console.log('edgemicro configuration complete!');
+    writeConsoleLog('log', 'edgemicro configuration complete!');
     setTimeout(cb, 50)
   });
 }
@@ -222,8 +224,8 @@ function addEnvVars(config) {
 
 function printError(err) {
   if (err.response) {
-    console.log(err.response.error);
+    writeConsoleLog('log',err.response.error);
   } else {
-    console.log(err);
+    writeConsoleLog('log',err);
   }
 }

--- a/cli/lib/deploy-auth.js
+++ b/cli/lib/deploy-auth.js
@@ -14,9 +14,10 @@ const url = require('url');
 const debug = require('debug')('edgemicro-auth')
 const _ = require('lodash')
 var exec = require('child_process').exec;
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
 
 var run = function(cmd, cb) {
-    //console.log('run %s',cmd)
+    //writeConsoleLog('log','run %s',cmd)
     var child = exec(cmd, {
         maxBuffer: 1024 * 500
     }, function(error, stdout, stderr) {
@@ -80,14 +81,14 @@ Deployment.prototype.deployWithLeanPayload = function deployWithLeanPayload(opti
 
     // copy bin folder into tmp
     tasks.push(function(cb) {
-        //console.log('copy auth app into tmp dir');
+        //writeConsoleLog('log','copy auth app into tmp dir');
         cpr(path.resolve(__dirname, '..', '..', 'node_modules', 'microgateway-edgeauth'), tmpDir.name, cb);
     });
 
 
     // copy bin folder into tmp
     tasks.push(function(cb) {
-        //console.log('copy config into tmp dir');
+        //writeConsoleLog('log','copy config into tmp dir');
         cpr(path.resolve(__dirname, '..', '..', 'config'), tmpDir.name + '/config', cb);
     });
 
@@ -126,7 +127,7 @@ Deployment.prototype.deployWithLeanPayload = function deployWithLeanPayload(opti
 
 // checks for previously deployed edgemicro internal proxies
 Deployment.prototype.checkDeployedInternalProxies = function checkDeployedInternalProxies(options, cb) {
-    //console.log('checking for previously deployed proxies')
+    //writeConsoleLog('log','checking for previously deployed proxies')
     const opts = {
         organization: options.org,
         api: 'edgemicro-internal',
@@ -158,7 +159,7 @@ Deployment.prototype.checkDeployedInternalProxies = function checkDeployedIntern
 
 // checks for previously deployed edgemicro proxies
 Deployment.prototype.checkDeployedProxies = function checkDeployedProxies(options, cb) {
-    //console.log('checking for previously deployed proxies')
+    //writeConsoleLog('log','checking for previously deployed proxies')
     const opts = {
         organization: options.org,
         api: 'edgemicro-auth',
@@ -263,7 +264,7 @@ Deployment.prototype.deployProxyWithPassword = function deployProxyWithPassword(
     if (options.runtimeUrl) {
       setEdgeMicroInternalEndpoint(dir + "/apiproxy/policies/Authenticate-Call.xml", options.runtimeUrl);
     } 
-    console.log('Give me a minute or two... this can take a while...');
+    writeConsoleLog('log','Give me a minute or two... this can take a while...');
     apigeetool.deployProxy(opts, function(err) {
         if (err) {
             if (err.code === 'ECONNRESET' && err.message === 'socket hang up') {
@@ -274,17 +275,17 @@ Deployment.prototype.deployProxyWithPassword = function deployProxyWithPassword(
 
             return callback(err);
         } else {
-            console.log('App %s deployed.', options.proxyName);
+            writeConsoleLog('log','App %s deployed.', options.proxyName);
             callback(null, options.runtimeUrl ? authUri + '/publicKey' : util.format(authUri + '/publicKey', options.org, options.env));
         }
 
-        //console.log('App %s added to your org. Now adding resources.', options.proxyName);
+        //writeConsoleLog('log','App %s added to your org. Now adding resources.', options.proxyName);
         /*    opts.password = options.password; // override a apigeetool side-effect bug
             installJavaCallout(managementUri, opts, function(err) {
               if (err) {
                 return callback(err);
               }
-              console.log('App %s deployed.', options.proxyName);
+              writeConsoleLog('log','App %s deployed.', options.proxyName);
               callback(null, options.runtimeUrl ? authUri + '/publicKey' : util.format(authUri + '/publicKey', options.org, options.env));
 
             });*/

--- a/cli/lib/gateway.js
+++ b/cli/lib/gateway.js
@@ -16,7 +16,8 @@ const uuid = require('uuid/v1');
 const debug = require('debug')('microgateway');
 const jsdiff = require('diff');
 const _ = require('lodash');
-
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
+edgeconfig.setConsoleLogger(writeConsoleLog);
 const Gateway = function() {};
 
 module.exports = function() {
@@ -27,9 +28,9 @@ Gateway.prototype.start = (options,cb) => {
     const self = this;
     try {
         fs.accessSync(ipcPath, fs.F_OK);
-        console.error('Edgemicro seems to be already running.');
-        console.error('If the server is not running, it might because of incorrect shutdown of the prevous start.');
-        console.error('Try removing ' + ipcPath + ' and start again');
+        writeConsoleLog('error','Edgemicro seems to be already running.');
+        writeConsoleLog('error','If the server is not running, it might because of incorrect shutdown of the prevous start.');
+        writeConsoleLog('error','Try removing ' + ipcPath + ' and start again');
         process.exit(1);
     } catch (e) {
         // Socket does not exist
@@ -68,13 +69,13 @@ Gateway.prototype.start = (options,cb) => {
     }, (err, config) => {
         if (err) {
             const exists = fs.existsSync(cache);
-            console.error("failed to retieve config from gateway. continuing, will try cached copy..");
-            console.error(err);
+            writeConsoleLog('error',"failed to retieve config from gateway. continuing, will try cached copy..");
+            writeConsoleLog('error',err);
             if (!exists) {
-                console.error('cache configuration ' + cache + ' does not exist. exiting.');
+                writeConsoleLog('error','cache configuration ' + cache + ' does not exist. exiting.');
                 return;
             } else {
-                console.log('using cached configuration from %s', cache);
+                writeConsoleLog('log','using cached configuration from %s', cache);
                 config = edgeconfig.load({
                     source: cache
                 });
@@ -122,15 +123,15 @@ Gateway.prototype.start = (options,cb) => {
             socket = new JsonSocket(socket);
             socket.on('message', (message) => {
                 if (message.command == 'reload') {
-                    console.log('Recieved reload instruction. Proceeding to reload');
+                    writeConsoleLog('log','Recieved reload instruction. Proceeding to reload');
                     mgCluster.reload(() => {
-                        console.log('Reload completed');
+                        writeConsoleLog('log','Reload completed');
                         socket.sendMessage(true);
                     });
                 } else if (message.command == 'stop') {
-                    console.log('Recieved stop instruction. Proceeding to stop');
+                    writeConsoleLog('log','Recieved stop instruction. Proceeding to stop');
                     mgCluster.terminate(() => {
-                        console.log('Stop completed');
+                        writeConsoleLog('log','Stop completed');
                         socket.sendMessage(true);
                         process.exit(0);
                     });
@@ -142,12 +143,12 @@ Gateway.prototype.start = (options,cb) => {
         });
 
         mgCluster.run();
-        console.log('PROCESS PID : ' + process.pid);
+        writeConsoleLog('log','PROCESS PID : ' + process.pid);
         fs.appendFileSync(pidPath, process.pid);
 
         process.on('exit', () => {
             if (!isWin) {
-                console.log('Removing the socket file as part of cleanup');
+                writeConsoleLog('log','Removing the socket file as part of cleanup');
                 fs.unlinkSync(ipcPath);
             }
 			fs.unlinkSync(pidPath);
@@ -162,7 +163,7 @@ Gateway.prototype.start = (options,cb) => {
         });
 
         process.on('uncaughtException',(err) => {
-            console.error(err);
+            writeConsoleLog('error',err);
             debug('Caught Unhandled Exception:');
             debug(err);
             process.exit(0);
@@ -177,7 +178,7 @@ Gateway.prototype.start = (options,cb) => {
 
         //start the polling mechanism to look for config changes
         var reloadOnConfigChange = (oldConfig, cache, opts) => {
-            console.log('Checking for change in configuration');
+            writeConsoleLog('log','Checking for change in configuration');
             if (configurl) opts.configurl = configurl;
             var self = this;
             edgeconfig.get(opts, (err, newConfig) => {
@@ -186,7 +187,7 @@ Gateway.prototype.start = (options,cb) => {
                 }
                 if (err) {
                     // failed to check new config. so try to check again after pollInterval
-                    console.error('Failed to check for change in Config. Will retry after ' + pollInterval + ' seconds');
+                    writeConsoleLog('error','Failed to check for change in Config. Will retry after ' + pollInterval + ' seconds');
                     setTimeout(() => {
                         reloadOnConfigChange(oldConfig, cache, opts);
                     }, pollInterval * 1000);
@@ -194,7 +195,7 @@ Gateway.prototype.start = (options,cb) => {
                     pollInterval = config.edgemicro.config_change_poll_interval ? config.edgemicro.config_change_poll_interval : pollInterval;
                     var isConfigChanged = hasConfigChanged(oldConfig, newConfig);
                     if (isConfigChanged) {
-                        console.log('Configuration change detected. Saving new config and Initiating reload');
+                        writeConsoleLog('log','Configuration change detected. Saving new config and Initiating reload');
                         edgeconfig.save(newConfig, cache);
                         clientSocket.sendMessage({
                             command: 'reload'
@@ -217,7 +218,7 @@ Gateway.prototype.start = (options,cb) => {
         }
         
         if ( cb && (typeof cb == "function") ) {
-            console.log("Calling cb")
+            writeConsoleLog('log',"Calling cb")
             cb();
         }
         
@@ -241,13 +242,13 @@ Gateway.prototype.reload = (options) => {
         }, (err, config) => {
             if (err) {
                 const exists = fs.existsSync(cache);
-                console.error("failed to retieve config from gateway. continuing, will try cached copy..");
-                console.error(err);
+                writeConsoleLog('error',"failed to retieve config from gateway. continuing, will try cached copy..");
+                writeConsoleLog('error',err);
                 if (!exists) {
-                    console.error('cache configuration ' + cache + ' does not exist. exiting.');
+                    writeConsoleLog('error','cache configuration ' + cache + ' does not exist. exiting.');
                     return;
                 } else {
-                    console.log('using cached configuration from %s', cache);
+                    writeConsoleLog('log','using cached configuration from %s', cache);
                     config = edgeconfig.load({
                         source: cache
                     })
@@ -261,9 +262,9 @@ Gateway.prototype.reload = (options) => {
             });
             socket.on('message', (success) => {
                 if (success) {
-                    console.log('Reload Completed Successfully');
+                    writeConsoleLog('log','Reload Completed Successfully');
                 } else {
-                    console.error('Reloading edgemicro was unsuccessful');
+                    writeConsoleLog('error','Reloading edgemicro was unsuccessful');
                 }
                 process.exit(0);
             });
@@ -272,7 +273,7 @@ Gateway.prototype.reload = (options) => {
     socket.on('error', (error) => {
         if (error) {
             if (error.code == 'ENOENT') {
-                console.error('edgemicro is not running.');
+                writeConsoleLog('error','edgemicro is not running.');
             }
         }
     });
@@ -288,9 +289,9 @@ Gateway.prototype.stop = (options) => {
         });
         socket.on('message', (success) => {
             if (success) {
-                console.log('Stop Completed Succesfully');
+                writeConsoleLog('log','Stop Completed Succesfully');
             } else {
-                console.error('Stopping edgemicro was unsuccessful');
+                writeConsoleLog('error','Stopping edgemicro was unsuccessful');
             }
             process.exit(0);
         });
@@ -298,7 +299,7 @@ Gateway.prototype.stop = (options) => {
     socket.on('error', (error) => {
         if (error) {
             if (error.code == 'ENOENT') {
-                console.error('edgemicro is not running.');
+                writeConsoleLog('error','edgemicro is not running.');
             }
         }
     });
@@ -312,14 +313,14 @@ Gateway.prototype.status = (options) => {
             command: 'status'
         });
         socket.on('message', (result) => {
-            console.log('edgemicro is running with ' + result + ' workers');
+            writeConsoleLog('log','edgemicro is running with ' + result + ' workers');
             process.exit(0);
         });
     });
     socket.on('error', (error)=> {
       if (error) {
         if (error.code == 'ENOENT') {
-          console.error('edgemicro is not running.');
+          writeConsoleLog('error','edgemicro is not running.');
           process.exit(1);
         }
       }

--- a/cli/lib/init.js
+++ b/cli/lib/init.js
@@ -2,6 +2,7 @@
 const fs = require('fs')
 const path = require('path');
 const configLocations = require('../../config/locations');
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
 
 module.exports =  function init(opts, cb) {
   if(typeof opts == 'function') {
@@ -16,7 +17,7 @@ module.exports =  function init(opts, cb) {
 
     fs.mkdir(destFileDir, () => {
       copyFile(srcFile, destFile, (err) => {
-        if ( err )  console.log("failed to init configpath file %s", err);
+        if ( err )  writeConsoleLog('log',"failed to init configpath file %s", err);
         cb(err, destFile);
       }); 
     });

--- a/cli/lib/key-gen.js
+++ b/cli/lib/key-gen.js
@@ -10,7 +10,8 @@ const util = require('util');
 const assert = require('assert')
 const edgeconfig = require('microgateway-config');
 const configLocations = require('../../config/locations');
-
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
+edgeconfig.setConsoleLogger(writeConsoleLog);
 
 const KeyGen = function() {
 
@@ -39,12 +40,12 @@ KeyGen.prototype.revoke = function(options, cb) {
         }, function(err, res) {
             err = translateError(err, res);
             if (err) {
-				console.log(err);
+				writeConsoleLog('log',err);
                 return cb(err);
             }
             if (res.statusCode >= 200 && res.statusCode <= 202) {
                 if (!res.body.region || !res.body.host) {
-                    cb(console.error('invalid response from region api', regionUrl, res.text));
+                    cb(writeConsoleLog('error','invalid response from region api', regionUrl, res.text));
                     return;
                 } else {
                     const credentialUrl = util.format('https://%s/edgemicro/%s/organization/%s/environment/%s', res.body.host, 'credential', options.org, options.env);
@@ -60,13 +61,13 @@ KeyGen.prototype.revoke = function(options, cb) {
                         }, function(er, re) {
                             er = translateError(er, re);
                             if (er) {
-								console.log(er);
+                              writeConsoleLog('log',er);
                                 return cb(er);
                             }
 							if (res.statusCode >= 200 && res.statusCode <= 202) {
-								console.log("key " + options.key + " revoked successfully");
+								writeConsoleLog('log',"key " + options.key + " revoked successfully");
 							} else {
-								console.log("revoking key " + options.key + " failed with reason code " + res.StatusCode)
+								writeConsoleLog('log',"revoking key " + options.key + " failed with reason code " + res.StatusCode)
 							}
                     });
 				}
@@ -79,19 +80,19 @@ KeyGen.prototype.generate = function generate(options, cb) {
   this.baseUri = config.edge_config.baseUri;
   this._generate(options, (err, result) => {
     if(err){
-      console.error("failed")
-      console.error(err)
+      writeConsoleLog('error',"failed")
+      writeConsoleLog('error',err)
 
       cb(err);
     }
-    console.info(config.edge_config.bootstrapMessage);
-    console.info('  bootstrap:', result.bootstrap);
-    console.log();
-    console.info(config.edge_config.keySecretMessage);
-    console.info('  key:', result.key);
-    console.info('  secret:', result.secret);
-    console.log();
-    console.log('finished');
+    writeConsoleLog('info',config.edge_config.bootstrapMessage);
+    writeConsoleLog('info','  bootstrap:', result.bootstrap);
+    writeConsoleLog('log');
+    writeConsoleLog('info',config.edge_config.keySecretMessage);
+    writeConsoleLog('info','  key:', result.key);
+    writeConsoleLog('info','  secret:', result.secret);
+    writeConsoleLog('log');
+    writeConsoleLog('log','finished');
     cb(err,result)
   });
 };
@@ -161,11 +162,11 @@ KeyGen.prototype._generate = function _generate(options, cb) {
           }
           if (res.statusCode >= 200 && res.statusCode <= 202) {
             if (!res.body.region || !res.body.host) {
-              cb(console.error('invalid response from region api', regionUrl, res.text));
+              cb(writeConsoleLog('error','invalid response from region api', regionUrl, res.text));
               return;
             }
 
-            console.log('configuring host', res.body.host, 'for region', res.body.region);
+            writeConsoleLog('log','configuring host', res.body.host, 'for region', res.body.region);
             const bootstrapUrl = util.format(baseUri, 'bootstrap', options.org, options.env);
             const parsedUrl = url.parse(bootstrapUrl);
             parsedUrl.host = res.body.host; // update to regional host
@@ -182,13 +183,13 @@ KeyGen.prototype._generate = function _generate(options, cb) {
 
           } else {
 
-            cb(console.error('error retrieving region for org', res.statusCode, res.text));
+            cb(writeConsoleLog('error','error retrieving region for org', res.statusCode, res.text));
 
           }
         });
       } else {
 
-        cb(console.error('error uploading credentials', res.statusCode, res.text));
+        cb(writeConsoleLog('error','error uploading credentials', res.statusCode, res.text));
 
       }
     });

--- a/cli/lib/private.js
+++ b/cli/lib/private.js
@@ -17,6 +17,8 @@ const cert = require('./cert-lib');
 const edgeconfig = require('microgateway-config');
 const configLocations = require('../../config/locations');
 const deploymentFx = require('./deploy-auth');
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
+edgeconfig.setConsoleLogger(writeConsoleLog);
 
 const DEFAULT_HOSTS = 'default,secure';
 
@@ -29,7 +31,7 @@ module.exports = function() {
 // begins edgemicro configuration process
 Private.prototype.configureEdgemicro = function(options, cb) {
     if (!fs.existsSync(configLocations.getDefaultPath(options.configDir))) {
-        console.error("Missing %s, Please run 'edgemicro init'", configLocations.getDefaultPath(options.configDir))
+        writeConsoleLog('error',"Missing %s, Please run 'edgemicro init'", configLocations.getDefaultPath(options.configDir))
         return cb("Please call edgemicro init first")
     }
 
@@ -44,16 +46,16 @@ Private.prototype.configureEdgemicro = function(options, cb) {
     assert(options.mgmtUrl, 'mgmtUrl is required');
 
     const cache = configLocations.getCachePath(options.org, options.env);
-    console.log('delete cache config');
+    writeConsoleLog('log','delete cache config');
     if (fs.existsSync(cache)) {
         fs.unlinkSync(cache);
-        console.log('deleted ' + cache);
+        writeConsoleLog('log','deleted ' + cache);
     }
 
     const targetPath = configLocations.getSourcePath(options.org, options.env);
     if (fs.existsSync(targetPath)) {
         fs.unlinkSync(targetPath);
-        console.log('deleted ' + targetPath);
+        writeConsoleLog('log','deleted ' + targetPath);
     }
 
     options.proxyName = this.name = 'edgemicro-auth';
@@ -84,7 +86,7 @@ Private.prototype.configureEdgemicro = function(options, cb) {
     var configFileDirectory = options.configDir || configLocations.homeDir;
 
     const that = this;
-    console.log('init config');
+    writeConsoleLog('log','init config');
     edgeconfig.init({
         source: configLocations.getDefaultPath(options.configDir),
         targetDir: configFileDirectory,
@@ -96,19 +98,19 @@ Private.prototype.configureEdgemicro = function(options, cb) {
         options.internaldeployed = false;
         that.deployment.checkDeployedProxies(options, (err, options) => {
             if (err) {
-                console.error(err);
+                writeConsoleLog('error',err);
                 if ( cb ) { cb(err) } else process.exit(1);
                 return;
             } else {
                 that.deployment.checkDeployedInternalProxies(options, (err, options) => {
                     if (err) {
-                        console.error(err);
+                        writeConsoleLog('error',err);
                         if ( cb ) { cb(err) } else process.exit(1);
                         return;
                     } else {
                         that.configureEdgemicroWithCreds(options, (err) => {
                             if (err) {
-                                console.error(err);
+                                writeConsoleLog('error',err);
                                 if ( cb ) { cb(err) } else process.exit(1);
                                 return;
                             }
@@ -178,7 +180,7 @@ Private.prototype.configureEdgeMicroInternalProxy = function configureEdgeMicroI
         function(parallelCb) {
             async.waterfall(calloutFlow, function(err, result) {
                 if (err) {
-                    console.log('error - editing apiproxy Callout.xml');
+                    writeConsoleLog('log','error - editing apiproxy Callout.xml');
                     return parallelCb(err);
                 }
 
@@ -219,7 +221,7 @@ Private.prototype.configureEdgeMicroInternalProxy = function configureEdgeMicroI
         tasks.push(function(parallelCb) {
             async.waterfall(defaultFlow, function(err, result) {
                 if (err) {
-                    console.log('error - editing apiproxy default.xml');
+                    writeConsoleLog('log','error - editing apiproxy default.xml');
                     return parallelCb(err);
                 }
 
@@ -247,42 +249,42 @@ Private.prototype.configureEdgemicroWithCreds = function configureEdgemicroWithC
 
     if (options.internaldeployed == false) {
         tasks.push(function(callback) {
-            console.log('configuring edgemicro internal proxy');
+            writeConsoleLog('log','configuring edgemicro internal proxy');
             that.configureEdgeMicroInternalProxy(options, callback);
         });
 
         tasks.push(function(callback) {
-            console.log('deploying edgemicro internal proxy');
+            writeConsoleLog('log','deploying edgemicro internal proxy');
             that.deployment.deployEdgeMicroInternalProxy(options, callback);
         });
     } else {
-        console.log('Proxy edgemicro-internal is already deployed');
+        writeConsoleLog('log','Proxy edgemicro-internal is already deployed');
     }
 
     if (options.deployed == false) {
         tasks.push(function(callback) {
-            console.log('deploying ', that.name, ' app');
+            writeConsoleLog('log','deploying ', that.name, ' app');
             that.deployment.deployWithLeanPayload(options, callback);
         });
     } else {
-        console.log(that.name, ' is already deployed');
+        writeConsoleLog('log',that.name, ' is already deployed');
     }
 
     tasks.push(function(callback) {
-        console.log('checking org for existing KVM');
+        writeConsoleLog('log','checking org for existing KVM');
         that.cert.checkPrivateCert(options, function(err, certs) {
             if (err) {
-                console.log('error checking for cert. Installing new cert.');
+                writeConsoleLog('log','error checking for cert. Installing new cert.');
                 that.cert.installCertWithPassword(options, callback);
             } else {
-                console.log('KVM already exists in your org');
+                writeConsoleLog('log','KVM already exists in your org');
                 that.cert.retrievePublicKeyPrivate(callback);
             }
         });
     });
 
     tasks.push(function(callback) {
-        console.log('generating keys');
+        writeConsoleLog('log','generating keys');
         that.generateKeysWithPassword(options, callback);
     });
 
@@ -329,18 +331,18 @@ Private.prototype.configureEdgemicroWithCreds = function configureEdgemicroWithC
                 agentConfig['analytics']['flushInterval'] = 500;
             }
 
-            console.log();
-            console.log('saving configuration information to:', agentConfigPath);
+            writeConsoleLog('log')
+            writeConsoleLog('log','saving configuration information to:', agentConfigPath);
             edgeconfig.save(agentConfig, agentConfigPath);
-            console.log();
+            writeConsoleLog('log')
 
             if (options.internaldeployed == false && options.deployed == false) {
-                console.log('vault info:\n', results[3]);
+                writeConsoleLog('log','vault info:\n', results[3]);
             } else if (options.internaldeployed == true && options.internaldeployed == false) {
-                console.log('vault info:\n', results[1]);
+                writeConsoleLog('log','vault info:\n', results[1]);
             }
 
-            console.log('edgemicro configuration complete!');
+            writeConsoleLog('log','edgemicro configuration complete!');
             cb();
 
         });
@@ -415,27 +417,27 @@ Private.prototype.generateKeysWithPassword = function generateKeysWithPassword(o
 
                     if (res.statusCode >= 200 && res.statusCode <= 202) {
                         if (!res.body.region || !res.body.host) {
-                            cb(console.error('invalid response from region api', regionUrl, res.text));
+                            cb(writeConsoleLog('error','invalid response from region api', regionUrl, res.text));
                             return;
                         }
 
-                        console.log('configuring host', res.body.host, 'for region', res.body.region);
+                        writeConsoleLog('log','configuring host', res.body.host, 'for region', res.body.region);
                         const parsedRes = url.parse(res.body.host);
                         parsedUrl.host = parsedRes.host; // update to regional host
-                        console.log();
-                        console.info(that.config.edge_config.keySecretMessage);
-                        console.info('  key:', key);
-                        console.info('  secret:', secret);
-                        console.log();
+                        writeConsoleLog('log')
+                        writeConsoleLog('info'that.config.edge_config.keySecretMessage);
+                        writeConsoleLog('info','  key:', key);
+                        writeConsoleLog('info','  secret:', secret);
+                        writeConsoleLog('log')
                         process.env.EDGEMICRO_KEY = key;
                         process.env.EDGEMICRO_SECRET = secret;
                         return cb(null, updatedUrl);
                     } else {
-                        cb(console.error('error retrieving region for org', res.statusCode, res.text));
+                        cb(writeConsoleLog('error','error retrieving region for org', res.statusCode, res.text));
                     }
                 });
             } else {
-                cb(console.error('error uploading credentials', res.statusCode, res.text));
+                cb(writeConsoleLog('error','error uploading credentials', res.statusCode, res.text));
             }
         });
     });
@@ -453,7 +455,7 @@ function translateError(err, res) {
 
 /*
 function optionError(message) {
-    console.error(message);
+    writeConsoleLog('error',message);
     this.help();
 }
 */

--- a/cli/lib/reload-cluster.js
+++ b/cli/lib/reload-cluster.js
@@ -108,7 +108,7 @@ var ReloadCluster = (file, opt) => {
     
         respawnerTimers.add(respawnerTimer);
     } catch (e) {
-      console.warn(e);
+      opt.logger.consoleLog('warn',e);
     }
   }
 
@@ -153,7 +153,7 @@ var ReloadCluster = (file, opt) => {
           worker.disconnect();  
         }
       } catch (e) {
-        console.warn(e);
+        opt.logger.consoleLog('warn',e);
       }
     } else {
       process.nextTick(forceKillWorker);

--- a/cli/lib/start-agent.js
+++ b/cli/lib/start-agent.js
@@ -3,6 +3,7 @@
 const cluster = require('cluster');
 const agentConfig = require('../../lib/agent-config');
 const assert = require('assert');
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
 
 var args;
 
@@ -15,7 +16,7 @@ assert(argsJson);
 
 agentConfig(argsJson, (e) => {
   if (e) {
-    console.error('edge micro failed to start', e);
+    writeConsoleLog('error','edge micro failed to start', e);
     return;
   }
   if (!cluster.isMaster) {
@@ -26,6 +27,6 @@ agentConfig(argsJson, (e) => {
       }
     });
   } else {
-    console.log('edge micro started');
+    writeConsoleLog('log','edge micro started');
   }
 });

--- a/cli/lib/token.js
+++ b/cli/lib/token.js
@@ -10,6 +10,8 @@ const jwt = require('jsonwebtoken');
 const assert = require('assert')
 
 const configLocations = require('../../config/locations');
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
+edgeconfig.setConsoleLogger(writeConsoleLog);
 
 const Token = function() {
 };
@@ -23,10 +25,10 @@ Token.prototype.decodeToken = function( options ) {
   const token = fs.readFileSync(path.resolve(options.file), 'utf8').trim();
   try{ 
     const decodedJWT = jwt.decode(token, {complete:true}); 
-    console.log(decodedJWT);
+    writeConsoleLog('log',decodedJWT);
     return decodedJWT;
   }catch(err) {
-    console.error(err);
+    writeConsoleLog('error',err);
   }
 }
 
@@ -67,7 +69,7 @@ Token.prototype.verifyToken = function(options, cb) {
         cb(err)
         return printError(err);
       }
-      console.log(result);
+      writeConsoleLog('log',result);
       cb(null,result)
     });
   });
@@ -106,7 +108,7 @@ Token.prototype.getToken = function(options, cb) {
       if ( cb ) cb(err)
       return printError(err);
     }
-    console.log(JSON.stringify(res.body, null, 2));
+    writeConsoleLog('log',JSON.stringify(res.body, null, 2));
     if ( cb ) cb(null, res.body);
   });
 }
@@ -126,15 +128,15 @@ function getPublicKey(organization, environment, authUri, isPublicCloud, cb) {
 
 function printError(err) {
   if (err.response) {
-    console.log(err.response.error);
+    writeConsoleLog('log',err.response.error);
   } else {
-    console.log(err);
+    writeConsoleLog('log',err);
   }
 }
 
 /*
 function optionError(message) {
-  console.error(message);
+  writeConsoleLog('error',message);
   this.help();
 }
 */

--- a/cli/lib/upgrade-edgeauth.js
+++ b/cli/lib/upgrade-edgeauth.js
@@ -7,6 +7,7 @@ var deployAuthLib = require('./deploy-auth');
 var deployAuth;
 
 const path = require('path');
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
 
 const UpgradeAuth = function() {
 
@@ -49,7 +50,7 @@ UpgradeAuth.prototype.upgradeauth = function upgradeauth(options, cb) {
 
     deployAuth.deployProxyWithPassword(options.mgmtUrl, 'na', opts, opts.directory, function(err, result) {
         if (err) {
-            console.log(err);
+            writeConsoleLog('log',err);
         }
     });
 

--- a/cli/lib/upgrade-kvm.js
+++ b/cli/lib/upgrade-kvm.js
@@ -4,7 +4,7 @@ const pem = require("pem");
 const util = require("util");
 const debug = require("debug")("jwkrotatekey");
 const request = require("request");
-
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
 
 function generateCredentialsObject(options) {
     if (options.token) {
@@ -36,18 +36,18 @@ UpgradeKVM.prototype.upgradekvm = function upgradekvm(options, cb) {
 
     var publicKeyURI = util.format('https://%s-%s.apigee.net/edgemicro-auth/publicKey', options.org, options.env);
 
-    console.log("Checking for certificate...");
+    writeConsoleLog('log',"Checking for certificate...");
     request({
         uri: publicKeyURI,
         auth: generateCredentialsObject(options),
         method: "GET"
     }, function(err, res, body) {
         if (err) {
-            console.error(err);
+            writeConsoleLog('error',err);
         } else {
-            console.log("Certificate found!");
+            writeConsoleLog('log',"Certificate found!");
             pem.getPublicKey(body, function(err, publicKey) {
-                console.log(publicKey.publicKey);
+                writeConsoleLog('log',publicKey.publicKey);
                 var updatekvmuri = util.format("%s/v1/organizations/%s/environments/%s/keyvaluemaps/%s",
                     options.baseuri, options.org, options.env, options.kvm);
                 var payload = {
@@ -78,9 +78,9 @@ UpgradeKVM.prototype.upgradekvm = function upgradekvm(options, cb) {
                         if ( cb ) { cb(err) } else process.exit(1);
                         return;
                     } if (res.statusCode != 200) {
-                        console.log("error upgrading KVM: "+ res.statusCode);
+                        writeConsoleLog('log',"error upgrading KVM: "+ res.statusCode);
                     } else {
-                        console.log("KVM update complete");
+                        writeConsoleLog('log',"KVM update complete");
                         process.exit(0);
                     }
                 });

--- a/cli/lib/verify.js
+++ b/cli/lib/verify.js
@@ -4,6 +4,8 @@ const path = require('path');
 const request = require('request');
 const async = require('async');
 const assert = require('assert');
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
+edgeconfig.setConsoleLogger(writeConsoleLog);
 
 const configLocations = require('../../config/locations');
 
@@ -45,18 +47,18 @@ Verify.prototype.verify = function verify(options) {
       },
         function (err, res) {
           if (err) {
-            console.log('verifying analytics negative case: FAIL');
+            writeConsoleLog('log','verifying analytics negative case: FAIL');
             return cb(err);
           }
 
           if (res.statusCode === 401) {
-            console.log('verifying analytics negative case: FAIL');
+            writeConsoleLog('log','verifying analytics negative case: FAIL');
             return cb(new Error('analytics up - got 401 Unauthorized. Invalid key/secret credentials.'));
           } else if (res.statusCode !== 500) {
-            console.log('verifying analytics negative case: FAIL');
+            writeConsoleLog('log','verifying analytics negative case: FAIL');
             return cb(new Error('analytics up - got code: ' + res.statusCode));
           } else {
-            console.log('verifying analytics negative case: OK');
+            writeConsoleLog('log','verifying analytics negative case: OK');
             cb();
           }
         });
@@ -73,18 +75,18 @@ Verify.prototype.verify = function verify(options) {
       },
         function (err, res, body) {
           if (err) {
-            console.log('verifying bootstrap url availability:FAIL');
+            writeConsoleLog('log','verifying bootstrap url availability:FAIL');
             return cb(err);
           }
 
           if (res.statusCode === 401) {
-            console.log('verifying bootstrap url availability:FAIL');
+            writeConsoleLog('log','verifying bootstrap url availability:FAIL');
             return cb(new Error('bootstrap - got 401 Unauthorized. Invalid key/secret credentials.'));
           } else if (res.statusCode !== 200) {
-            console.log('verifying bootstrap url availability:FAIL');
+            writeConsoleLog('log','verifying bootstrap url availability:FAIL');
             return cb(new Error('bootstrap - got code: ' + res.statusCode))
           } else {
-            console.log('verifying bootstrap url availability:OK');
+            writeConsoleLog('log','verifying bootstrap url availability:OK');
             cb();
           }
         })
@@ -97,15 +99,15 @@ Verify.prototype.verify = function verify(options) {
       },
         function (err, res, body) {
           if (err) {
-            console.log('verifying jwt_public_key availability: FAIL');
+            writeConsoleLog('log','verifying jwt_public_key availability: FAIL');
             return cb(err);
           }
 
           if (res.statusCode !== 200) {
-            console.log('verifying jwt_public_key availability: FAIL');
+            writeConsoleLog('log','verifying jwt_public_key availability: FAIL');
             return cb(new Error('jwt - got code: ' + res.statusCode));
           } else {
-            console.log('verifying jwt_public_key availability: OK');
+            writeConsoleLog('log','verifying jwt_public_key availability: OK');
             cb();
           }
         });
@@ -124,15 +126,15 @@ Verify.prototype.verify = function verify(options) {
       },
         function (err, res, body) {
           if (err) {
-            console.log('verifying products availability: FAIL');
+            writeConsoleLog('log','verifying products availability: FAIL');
             return cb(err);
           }
 
           if (res.statusCode !== 200) {
-            console.log('verifying products availability: FAIL');
+            writeConsoleLog('log','verifying products availability: FAIL');
             return cb(new Error('products - got code: ' + res.statusCode));
           } else {
-            console.log('verifying products availability: OK');
+            writeConsoleLog('log','verifying products availability: OK');
             cb();
           }
         });
@@ -163,11 +165,11 @@ Verify.prototype.verify = function verify(options) {
           });
       }, function (err) {
         if (err) {
-          console.log('verifying quota with configured products: FAIL');
+          writeConsoleLog('log','verifying quota with configured products: FAIL');
           cb(err);
         }
 
-        console.log('verifying quota with configured products: OK');
+        writeConsoleLog('log','verifying quota with configured products: OK');
         cb();
       });
     },
@@ -202,18 +204,18 @@ Verify.prototype.verify = function verify(options) {
       },
         function (err, res, body) {
           if (err) {
-            console.log('verifying analytics with payload: FAIL');
+            writeConsoleLog('log','verifying analytics with payload: FAIL');
             return cb(err);
           }
 
           if (res.statusCode === 401) {
-            console.log('verifying analytics with payload: FAIL');
+            writeConsoleLog('log','verifying analytics with payload: FAIL');
             return cb(new Error('analytics synthetic - got 401 Unauthorized. Invalid key/secret credentials.'));
           } else if (res.statusCode !== 200) {
-            console.log('verifying analytics with payload: FAIL');
+            writeConsoleLog('log','verifying analytics with payload: FAIL');
             return cb(new Error('analytics synthetic - got code: ' + res.statusCode));
           } else {
-            console.log('verifying analytics with payload: OK');
+            writeConsoleLog('log','verifying analytics with payload: OK');
             return cb();
           }
         })
@@ -231,7 +233,7 @@ Verify.prototype.verify = function verify(options) {
       }
       downloadedConfig = config;
       async.series(tasks, function (asyncErr, res) {
-        console.log('verification complete');
+        writeConsoleLog('log','verification complete');
         agent.close(process.exit); // close and stop agent
       });
     })
@@ -241,8 +243,8 @@ Verify.prototype.verify = function verify(options) {
 }
 function printError(err) {
   if (err.response) {
-    console.log(err.response.error);
+    writeConsoleLog('log',err.response.error);
   } else {
-    console.log(err);
+    writeConsoleLog('log',err);
   }
 }

--- a/cli/package.js
+++ b/cli/package.js
@@ -12,10 +12,11 @@ const os = require('os');
 const path = require('path');
 const parseArgs = require('minimist');
 const yaml = require('js-yaml');
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
 
 const argv = parseArgs(process.argv.slice(2));
 if (!argv.version) {
-  console.error('Usage:', process.argv[1], '--version <major.minor.patch>');
+  writeConsoleLog('error','Usage:', process.argv[1], '--version <major.minor.patch>');
   process.exit(1);
 }
 
@@ -31,13 +32,13 @@ async.parallel([
   function(cb) { available('tsc', cb); }
 ], function(err, results) {
   if (err) {
-    console.error('gulp/tsc not found in path (try "npm i -g gulp typescript")');
+    writeConsoleLog('error','gulp/tsc not found in path (try "npm i -g gulp typescript")');
     process.exit(1);
   }
 });
 
 process.chdir(buildDir);
-console.info('building package in', buildDir);
+writeConsoleLog('info','building package in', buildDir);
 
 const topLevelFiles = [
   'build.yaml',
@@ -105,17 +106,17 @@ async.series(tasks, function(err, results) {
 });
 
 function git_clone(repo, branch, callback) {
-  console.log('git clone', repo);
+  writeConsoleLog('log','git clone', repo);
   exec(
     'git clone ' + (branch ? '-b ' + branch + ' ': '') + '-q ' + repo,
     function(error, stdout, stderr) {
-      // console.info(stdout);
-      console.error(stderr);
+      // writeConsoleLog('info',stdout);
+      writeConsoleLog('error',stderr);
       if (error) {
-        console.error('error cloning repo', repo, error);
+        writeConsoleLog('error','error cloning repo', repo, error);
         callback(error);
       } else {
-        console.info('cloned', repo);
+        writeConsoleLog('info','cloned', repo);
         callback();
       }
     }
@@ -123,18 +124,18 @@ function git_clone(repo, branch, callback) {
 }
 
 function npm_install(dir, production, callback) {
-  console.log('npm install', dir, production ? '(production)' : '(development)');
+  writeConsoleLog('log','npm install', dir, production ? '(production)' : '(development)');
   exec(
     'npm install ' + (production ? '--production' : ''),
     {cwd: dir},
     function(error, stdout, stderr) {
-      // console.info(stdout);
-      console.error(stderr);
+      // writeConsoleLog('info',stdout);
+      writeConsoleLog('error',stderr);
       if (error) {
-        console.error('error running npm install in dir', dir, error);
+        writeConsoleLog('error','error running npm install in dir', dir, error);
         callback(error);
       } else {
-        console.info('installed modules in', dir);
+        writeConsoleLog('info','installed modules in', dir);
         callback();
       }
     }
@@ -142,7 +143,7 @@ function npm_install(dir, production, callback) {
 }
 
 function build_properties(repo, callback) {
-  console.log('creating build properties in', repo);
+  writeConsoleLog('log','creating build properties in', repo);
   const properties = {};
   properties.version = argv.version;
   properties.date = (new Date()).toISOString();
@@ -150,9 +151,9 @@ function build_properties(repo, callback) {
     'git show HEAD|grep commit|cut -f2 -d" "',
     {cwd: repo},
     function(error, stdout, stderr) {
-      console.error(stderr);
+      writeConsoleLog('error',stderr);
       if (error) {
-        console.error('error running "git show HEAD" in repo', repo, error);
+        writeConsoleLog('error','error running "git show HEAD" in repo', repo, error);
         callback(error);
       } else {
         properties.head = stdout.trim();
@@ -166,7 +167,7 @@ function build_properties(repo, callback) {
 
 function update_version(repo, callback) {
   const pkgJSON = path.join(repo, 'package.json');
-  console.log('updating version in', pkgJSON);
+  writeConsoleLog('log','updating version in', pkgJSON);
   const pkg = JSON.parse(fs.readFileSync(pkgJSON));
   pkg.version = argv.version;
   fs.writeFileSync(pkgJSON, JSON.stringify(pkg, null, 2));
@@ -175,14 +176,14 @@ function update_version(repo, callback) {
 
 function git_tag(repo, callback) {
   const tag = 'v' + argv.version;
-  console.log('tagging repo', repo, 'with version', tag);
+  writeConsoleLog('log','tagging repo', repo, 'with version', tag);
   exec(
     'git tag ' + tag,
     {cwd: repo},
     function(error, stdout, stderr) {
-      console.error(stderr);
+      writeConsoleLog('error',stderr);
       if (error) {
-        console.error('error running "git tag" in repo', repo, error);
+        writeConsoleLog('error','error running "git tag" in repo', repo, error);
         callback(error);
       } else {
         callback();
@@ -192,18 +193,18 @@ function git_tag(repo, callback) {
 }
 
 function gulp(dir, target, callback) {
-  console.log('gulp', target);
+  writeConsoleLog('log','gulp', target);
   exec(
     'gulp ' + target,
     {cwd: dir},
     function(error, stdout, stderr) {
-      // console.info(stdout);
-      console.error(stderr);
+      // writeConsoleLog('info',stdout);
+      writeConsoleLog('error',stderr);
       if (error) {
-        console.error('error running gulp in dir', dir, error);
+        writeConsoleLog('error','error running gulp in dir', dir, error);
         callback(error);
       } else {
-        console.info('compiled sources in', dir);
+        writeConsoleLog('info','compiled sources in', dir);
         callback();
       }
     }
@@ -213,7 +214,7 @@ function gulp(dir, target, callback) {
 function zip(zipfile, dir, dirs, excludes, callback) {
   const command = '/usr/bin/zip';
   const args = ['-q', '--symlinks', '-r', zipfile].concat(dirs, '-x', excludes);
-  console.log(dir, command, args.join(' '));
+  writeConsoleLog('log',dir, command, args.join(' '));
   const zip = spawn(command, args, {
     cwd: dir,
     stdio: 'inherit'
@@ -221,10 +222,10 @@ function zip(zipfile, dir, dirs, excludes, callback) {
 
   zip.on('exit', function(error) {
     if (error) {
-      console.error('error creating zip', error);
+      writeConsoleLog('error','error creating zip', error);
       callback(error);
     } else {
-      console.info('built', path.join(dir, zipfile));
+      writeConsoleLog('info','built', path.join(dir, zipfile));
       callback();
     }
   });
@@ -233,7 +234,7 @@ function zip(zipfile, dir, dirs, excludes, callback) {
 function available(cmd, callback) {
   exec('/usr/bin/which ' + cmd,
     function(error, stdout, stderr) {
-      // console.info(error, stdout);
+      // writeConsoleLog('info',error, stdout);
       callback(error, stdout);
     }
   );

--- a/forever.js
+++ b/forever.js
@@ -1,11 +1,12 @@
 'use strict';
 
 var forever = require('forever-monitor');
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
 try { 
   var foreverOptions = require('./forever.json');
 } catch (err) {
-  console.error(err);
-  console.log("using default forever options");
+  writeConsoleLog('error',err);
+  writeConsoleLog('log',"using default forever options");
   var foreverOptions =  { max: 3, silent: false, killTree: true, minUptime: 2000 };
 }
 

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -7,6 +7,7 @@ const yaml = require('js-yaml');
 const _ = require('lodash');
 const assert = require('assert');
 const builtInPlugins = require('microgateway-plugins');
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
 
 /**
  *load plugins into the gateway
@@ -20,12 +21,12 @@ const Plugins = function (gateway, pluginDir, config) {
 function normalizePluginDir(pluginDir) {
   var pluginCandidate = null;
   if (pluginDir) {
-    console.log('using pluginDir')
+    writeConsoleLog('log','using pluginDir')
     if (!fs.existsSync(pluginDir)) {
-      console.log('pluginDir %s does not exist', pluginDir);
+      writeConsoleLog('log','pluginDir %s does not exist', pluginDir);
     } else {
       pluginCandidate = path.normalize(pluginDir);
-      console.log('using plugin dir %s', pluginCandidate)
+      writeConsoleLog('log','using plugin dir %s', pluginCandidate)
     }
   }
   return pluginCandidate;
@@ -83,7 +84,7 @@ function _reorderPlugins(dirs, config) {
       dirs.splice(index, 1);
       return true;
     } else {
-      console.warn('sequenced plugin not found:', plugin);
+      writeConsoleLog('warn','sequenced plugin not found:', plugin);
       return false;
     }
   });

--- a/lib/server.js
+++ b/lib/server.js
@@ -6,6 +6,7 @@ const os = require('os');
 const url = require('url');
 const _ = require('lodash');
 const cluster = require('cluster')
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
 /**
  *  new agent
  */
@@ -60,7 +61,7 @@ Agent.prototype.start = function start(token,pluginDir, config, cb) {
 
     this.gatewayServer = gateway(pluginDir,config);
     this.gatewayServer.start((err) => {
-      if ( err ) console.error(err);
+      if ( err ) writeConsoleLog('error',err);
       if ( cb ) cb(null, config);
 
     });


### PR DESCRIPTION
- Replace console calls with centralized function writeConsoleLog.
- Pass writeConsoleLog to config because config doesn't having microgateway-core as a dependency to directly import writeConsoleLog