### PR TITLE
for306 138722809 Add stack_trace flag to logging

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -18,6 +18,7 @@ edgemicro:
     dir: /var/tmp
     stats_log_interval: 60
     rotate_interval: 24
+    stack_trace: false
   plugins:
     sequence:
       - oauth


### PR DESCRIPTION
Add stack_trace flag to logging in yaml config.
If flag is set to true error stack will be printed in log file.