### PR TITLE
for306 140090250 Add logger for plugins logs

### DIFF
--- a/cli/lib/reload-cluster.js
+++ b/cli/lib/reload-cluster.js
@@ -9,6 +9,7 @@ const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
 const CONSOLE_LOG_TAG_COMP = 'microgateway reload cluster';
 
 const specialLists = require('./util/item-managers')
+const pluginLogger = require('./util/plugin-logger')
 
 const PURGE_INTERVAL = 60000;
 //
@@ -542,7 +543,11 @@ class ClusterManager extends EventEmitter {
       // whenever worker sends a message, emit it to the channels
       worker.on('message', (message) => {
         if ( this.opt.logger ) {
-          this.opt.logger.writeLogRecord(message);
+          if(message && typeof message === 'object' && message.isPluginLog){
+            pluginLogger.writePluginLogToFile(message.data,message.pluginName,worker.id);
+          } else {
+            this.opt.logger.writeLogRecord(message);
+          }
         }
         this.emit('message', worker, message);
       });

--- a/cli/lib/util/plugin-logger.js
+++ b/cli/lib/util/plugin-logger.js
@@ -1,0 +1,76 @@
+
+'use strict';
+
+const fs = require('fs');
+const mkdir = require('mkdirp');
+const os = require('os');
+const path = require('path');
+const util = require('util');
+const cluster = require('cluster')
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
+
+const CONSOLE_LOG_TAG = 'microgateway plugin-logger';
+
+// using a WriteStream here causes excessive memory growth under high load (with node v0.12.6, jul 2015)
+var pluginlogFileFd;
+var pluginlogFilePath;
+var pluginLogFailWarn = false;
+var writeLogInProgress = false;
+var logRecords = [];
+var logoffset = 0;
+const pluginLogDir = '/var/tmp';
+
+// create differnent file for plugins logs
+const writePluginLogToFile = function (record, pluginName, workerId) {
+    if(!record) return;
+    try {
+        const Timestamp = new Date().toISOString();
+        record = Timestamp+' '+process.pid+' '+workerId+' '+JSON.stringify(record)+os.EOL;
+        let pluginlogFilePathNew = _calculatePluginLogFilePath(pluginLogDir, pluginName);
+        if( !pluginlogFilePath || pluginlogFilePath !== pluginlogFilePathNew ) {
+            pluginlogFilePath = pluginlogFilePathNew;
+            pluginlogFileFd = fs.openSync(pluginlogFilePath, 'a', 0o0600);
+        }
+        if (record) logRecords.push(record);
+        if (writeLogInProgress || (logRecords.length === 0)) {
+            return record;
+        }
+
+        writeLogInProgress = true;
+        const buffer = logRecords.join('');
+        logRecords = [];
+
+        fs.write(pluginlogFileFd, buffer, logoffset, 'utf8', function (err, written) {
+            writeLogInProgress = false;
+
+            if (err) {
+                if (!pluginLogFailWarn) {
+                    // print warning once, dumping every failure to console would overwhelm the console
+                    writeConsoleLog('warn', { component: CONSOLE_LOG_TAG }, 'error writing log', err);
+                    pluginLogFailWarn = true;
+                }
+            } else {
+                logoffset += written;
+            }
+            if (logRecords.length > 0) {
+                process.nextTick(function () {
+                    writePluginLogToFile();
+                });
+            }
+        });
+        return buffer;
+    } catch (e) {
+        writeConsoleLog('warn', { component: CONSOLE_LOG_TAG }, 'error writing plugin logger', e);
+    }
+}
+
+const _calculatePluginLogFilePath = (pluginLogDir, pluginName) => {
+    var d=new Date()
+    var logDate = d.getHours()+'-'+d.getDate()+'-'+d.getMonth()+'-'+d.getFullYear();
+    const baseFileName = util.format('edgemicro-%s-%s-%s.log', os.hostname(), pluginName, logDate);
+    const logFilePath = path.join(pluginLogDir, baseFileName);
+    return logFilePath;
+};
+
+
+module.exports.writePluginLogToFile = writePluginLogToFile;


### PR DESCRIPTION
Plugin logger will create different file for each plugin.
command to log :
process.send({isPluginLog:true, data: ObjectToLog, pluginName:'<YOUR_PLUGIN_NAME>'});

Eg: process.send({isPluginLog:true, data: quotaInitResLogData, pluginName:'quota'});

Every 1 hour new file will be created.