### PR TITLE
feature: edgemicro genkeys now supports SAML enabled orgs

### DIFF
--- a/cli/lib/configure.js
+++ b/cli/lib/configure.js
@@ -34,12 +34,12 @@ module.exports = function () {
   return new Configure();
 }
 
-Configure.prototype.configure = function configure(options, cb) {    
+Configure.prototype.configure = function configure(options, cb) {
   if (!fs.existsSync(configLocations.getDefaultPath(options.configDir))) {
     writeConsoleLog('error',{component: CONSOLE_LOG_TAG_COMP},"Missing %s, Please run 'edgemicro init'",configLocations.getDefaultPath())
     return cb("Please call edgemicro init first")
   }
-    
+
   defaultConfig = edgeconfig.load({ source: configLocations.getDefaultPath(options.configDir) });
   addEnvVars(defaultConfig);
   deployAuth = deployAuthLib(defaultConfig.edge_config, null)
@@ -115,12 +115,12 @@ Configure.prototype.configure = function configure(options, cb) {
 function configureEdgemicroWithCreds(options, cb) {
   var tasks = [],
     agentConfigPath;
-	
+
   if (options.deployed === false) {
     tasks.push(function (callback) {
       deployAuth.deployWithLeanPayload(options, callback);
     });
-  } 
+  }
 
   tasks.push(
     function (callback) {
@@ -161,7 +161,7 @@ function configureEdgemicroWithCreds(options, cb) {
 
     addEnvVars(agentConfig);
 
-    if (options.deployed === false) {  
+    if (options.deployed === false) {
       agentConfig['edge_config']['jwt_public_key'] = (options.url ? options.url+"/edgemicro-auth/publicKey" : results[0]); // get deploy results
       agentConfig['edge_config'].bootstrap = results[2].bootstrap; // get genkeys results
     } else {

--- a/cli/lib/key-gen.js
+++ b/cli/lib/key-gen.js
@@ -34,10 +34,7 @@ KeyGen.prototype.revoke = function(options, cb) {
 
     request({
             uri: regionUrl,
-            auth: {
-                username: options.key,
-                password: options.secret
-            },
+            auth: generateCredentialsObject(options),
             json: true
         }, function(err, res) {
             err = translateError(err, res);
@@ -73,7 +70,7 @@ KeyGen.prototype.revoke = function(options, cb) {
 							}
                     });
 				}
-			}			
+			}
 		});
 }
 
@@ -134,10 +131,7 @@ KeyGen.prototype._generate = function _generate(options, cb) {
     request({
       uri: credentialUrl,
       method: 'POST',
-      auth: {
-        username: options.username,
-        password: options.password
-      },
+      auth: generateCredentialsObject(options),
       json: keys
     }, function(err, res) {
       err = translateError(err, res);
@@ -199,6 +193,18 @@ KeyGen.prototype._generate = function _generate(options, cb) {
 
 }
 
+function generateCredentialsObject(options) {
+    if (options.token) {
+        return {
+            'bearer': options.token
+        };
+    } else {
+        return {
+            user: options.username,
+            pass: options.password
+        };
+    }
+}
 
 function translateError(err, res) {
   if (!err && res.statusCode >= 400) {


### PR DESCRIPTION
Problem:
The `edgemicro genkeys` command does not allow a user to enter `-t` or `--token`.  It only allows username and password, which is acceptable as long as your Apigee organization does not have SSO enabled.  Once you enable SSO, then you must use JWT token for all command line tools.  

Solution:
This pull request updates the `edgemicro genkeys` command to allow a user to enter `-t` or `--token`.  

Please review and test this pull request. 