### PR TITLE
Fix bug 145023519 and update the reload cluster logic

### DIFF
--- a/cli/lib/gateway.js
+++ b/cli/lib/gateway.js
@@ -280,7 +280,10 @@ Gateway.prototype.reload = (options) => {
                 command: 'reload'
             });
             socket.on('message', (success) => {
-                if (success) {
+                if (typeof success === 'object' && success.message) {
+                    writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP}, success.message);
+                }
+                else if (success) {
                     writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP},'Reload Completed Successfully');
                 } else {
                     writeConsoleLog('error',{component: CONSOLE_LOG_TAG_COMP},'Reloading edgemicro was unsuccessful');


### PR DESCRIPTION
Reload will not shut down old workers before starting new ones
Start a new worker, then stop an old worker. Wait till the worker exits gracefully or till a configurable timeout. If the worker did not exit gracefully, kill it.
Only then, start with the next worker
If already reloading, ignore new reloads