### PR TITLE
Update docker image to remove alpine

### DIFF
--- a/kubernetes/docker/edgemicro/Dockerfile
+++ b/kubernetes/docker/edgemicro/Dockerfile
@@ -1,20 +1,20 @@
-FROM node:12-alpine
+FROM node:12-buster-slim
 
 COPY installnode.sh /tmp
-COPY --chown=100:101 installedgemicro.sh /tmp
+COPY --chown=101:101 installedgemicro.sh /tmp
 
 # create user and group for microgateway
-RUN apk add --no-cache sed grep && \
-    addgroup -S apigee -g 101 && \
-    adduser -s /bin/sh -u 100 -S -G apigee apigee -h /opt/apigee
+#RUN apk add --no-cache sed grep && \
+RUN addgroup --system --gid 101 apigee && \
+    adduser --shell /bin/bash --uid 101 --system --ingroup apigee --home /opt/apigee apigee
 
 ENV NODE_ENV production
 
 #install node.js
 RUN chmod +x /tmp/installnode.sh && \
-    sh /tmp/installnode.sh && \
+    /bin/bash /tmp/installnode.sh && \
     rm -f /tmp/installnode.sh && \
-    deluser --remove-home node
+    userdel --remove node
 
 USER apigee
 WORKDIR /opt/apigee
@@ -28,10 +28,10 @@ VOLUME /opt/apigee/plugins
 # COPY cert.pem /opt/apigee/.edgemicro
 
 # copy entrypoint
-COPY --chown=100:101 entrypoint.sh /opt/apigee
+COPY --chown=101:101 entrypoint.sh /opt/apigee
 
 # initialize edgemicro
-RUN sh /tmp/installedgemicro.sh&& \
+RUN /bin/bash /tmp/installedgemicro.sh&& \
     rm -f /tmp/installedgemicro.sh
 
 # Expose ports

--- a/kubernetes/docker/edgemicro/Dockerfile.beta
+++ b/kubernetes/docker/edgemicro/Dockerfile.beta
@@ -5,7 +5,7 @@ COPY install-beta.sh /tmp
 # create user and group for microgateway
 RUN apk add --no-cache sed grep && \
     addgroup -S apigee -g 101 && \
-    adduser -s /bin/sh -u 100 -S -G apigee apigee -h /opt/apigee
+    adduser -s /bin/bash -u 100 -S -G apigee apigee -h /opt/apigee
 
 WORKDIR /opt/apigee
 
@@ -16,7 +16,7 @@ ENV NODE_ENV production
 
 #install and initialize microgateway
 RUN chmod +x /tmp/install-beta.sh && \
-    sh /tmp/install-beta.sh && \
+    /bin/bash /tmp/install-beta.sh && \
     rm -f /tmp/install-beta.sh && \
     deluser --remove-home node
 

--- a/kubernetes/docker/edgemicro/clean.sh
+++ b/kubernetes/docker/edgemicro/clean.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 docker stop $(docker ps -aqf name=microgateway)
 docker rm $(docker ps -aqf name=microgateway)
 rm -fr config/*-cache-*.yaml

--- a/kubernetes/docker/edgemicro/entrypoint.sh
+++ b/kubernetes/docker/edgemicro/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 APIGEE_ROOT="/opt/apigee"
 EDGEMICRO_PLUGIN_DIRECTORY="/opt/apigee/plugins"
@@ -115,9 +115,9 @@ start_edge_micro() {
 
   if [[ -n "$DEBUG" ]]
     then
-    /bin/sh -c "$DEBUG && $CMDSTRING"
+    /bin/bash -c "$DEBUG && $CMDSTRING"
   else
-    /bin/sh -c "$CMDSTRING"
+    /bin/bash -c "$CMDSTRING"
   fi
 
   echo $CMDSTRING
@@ -128,7 +128,7 @@ start_edge_micro  2>&1 | tee -i $LOG_FILE
 # SIGUSR1-handler
 my_handler() {
   echo "my_handler" >> /tmp/entrypoint.log
-  /bin/sh -c "cd ${APIGEE_ROOT} && edgemicro stop" 2>&1  | tee -i $LOG_FILE
+  /bin/bash -c "cd ${APIGEE_ROOT} && edgemicro stop" 2>&1  | tee -i $LOG_FILE
 }
 
 # SIGTERM-handler
@@ -143,7 +143,7 @@ term_handler() {
     echo "term_handler_sleep $EDGEMICRO_STOP_DELAY" >> /tmp/entrypoint.log
     sleep $EDGEMICRO_STOP_DELAY
   fi
-  /bin/sh -c "cd ${APIGEE_ROOT} && edgemicro stop"  2>&1 | tee -i $LOG_FILE
+  /bin/bash -c "cd ${APIGEE_ROOT} && edgemicro stop"  2>&1 | tee -i $LOG_FILE
   exit 143; # 128 + 15 -- SIGTERM
 }
 

--- a/kubernetes/docker/edgemicro/install-beta.sh
+++ b/kubernetes/docker/edgemicro/install-beta.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set echo off
 
@@ -11,7 +11,7 @@ chown apigee:apigee /opt/apigee && \
     mkdir /opt/apigee/.edgemicro && \
     chown apigee:apigee /opt/apigee/.edgemicro && \
     ln -s /opt/apigee/.edgemicro /root/.edgemicro && \
-    su - apigee -s /bin/sh -c "edgemicro init" && \
+    su - apigee -s /bin/bash -c "edgemicro init" && \
     chmod +x /opt/apigee/entrypoint.sh && \
     chown apigee:apigee /opt/apigee/entrypoint.sh && \
     ln -s /opt/apigee/entrypoint.sh /usr/local/bin/entrypoint

--- a/kubernetes/docker/edgemicro/installedgemicro.sh
+++ b/kubernetes/docker/edgemicro/installedgemicro.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set echo off
 

--- a/kubernetes/docker/edgemicro/installnode.sh
+++ b/kubernetes/docker/edgemicro/installnode.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 set echo off
 npm install --only=production --no-optional -g edgemicro


### PR DESCRIPTION
Node alpine image contains busybox and may cause conflicts.
Moving to debian:buster-slim based node image