### PR TITLE
Quote EDGEMICRO_CONFIG to properly decode it's contents

### DIFF
--- a/kubernetes/docker/edgemicro/entrypoint.sh
+++ b/kubernetes/docker/edgemicro/entrypoint.sh
@@ -31,7 +31,7 @@ start_edge_micro() {
 
   if [[ -n "$EDGEMICRO_CONFIG"  ]]
     then
-      echo $EDGEMICRO_CONFIG | base64 -d > ${APIGEE_ROOT}/.edgemicro/$EDGEMICRO_ORG-$EDGEMICRO_ENV-config.yaml
+      echo "$EDGEMICRO_CONFIG" | base64 -d > ${APIGEE_ROOT}/.edgemicro/$EDGEMICRO_ORG-$EDGEMICRO_ENV-config.yaml
       chown apigee:apigee ${APIGEE_ROOT}/.edgemicro/*
   fi
 


### PR DESCRIPTION
Without this minor change we were unable to start the image when using the "EDGEMICRO_CONFIG" env variable.