### PR TITLE
Use new endpoint for upgrade kvm and rotate key

### DIFF
--- a/cli/cmd-private.js
+++ b/cli/cmd-private.js
@@ -81,26 +81,23 @@ module.exports = function() {
         .command('upgradekvm')
         .option('-o, --org <org>', 'the organization')
         .option('-e, --env <env>', 'the environment')
-        .option('-u, --username <user>', 'username of the organization admin')
-        .option('-p, --password <password>', 'password of the organization admin')
+        .option('-k, --key <key>', 'key for authenticating with Edge')
+        .option('-s, --secret <secret>', 'secret for authenticating with Edge')
         .option('-v, --virtualhost <virtualhost>', 'virtual host of the proxy')
-        .option('-m, --mgmt-url <mgmtUrl>', 'the URL of the management server')
         .option('-t, --token <token>', 'OAuth token to use with management API')
+        .option('-p, --proxyuri <proxyuri>', 'proxyuri for edgeauth proxy')
         .description('upgrade kvm to support JWT Key rotation')
         .action((options) => {
             options.error = optionError(options);
             options.token = options.token || process.env.EDGEMICRO_SAML_TOKEN;
 
             if (!options.token) {
-                if (!options.username) {
-                    return options.error('username is required');
+                if (!options.key) {
+                    return options.error('key is required');
                 }
-
-                promptForPassword(options, (options) => {
-                    if (!options.password) {
-                        return options.error('password is required');
-                    }
-                });
+                if (!options.secret) {
+                    return options.error('secret is required');
+                }
             }
 
             if (!options.org) {
@@ -109,17 +106,13 @@ module.exports = function() {
             if (!options.env) {
                 return options.error('env is required');
             }
-            if (!options.runtimeUrl) {
-                return options.error('runtimeUrl is required');
+            if (!options.proxyuri) {
+                return options.error('proxyuri is required')
             }
-            if (!options.mgmtUrl) {
-                return options.error('mgmtUrl is required');
+            if (options.proxyuri && !options.proxyuri.includes('http')) {
+                return options.error('proxyuri requires a prototcol http or https')
             }
-            if (!options.mgmtUrl.includes('http')) {
-                return options.error('runtimeUrl requires a prototcol http or https')
-            }
-
-            upgradekvm.upgradekvm(options, () => {});
+            upgradekvm.upgradekvm(options);
 
         });
 
@@ -169,26 +162,23 @@ module.exports = function() {
         .command('rotatekey')
         .option('-o, --org <org>', 'the organization')
         .option('-e, --env <env>', 'the environment')
-        .option('-u, --username <user>', 'username of the organization admin')
-        .option('-p, --password <password>', 'password of the organization admin')
-        .option('-k, --kid <kid>', 'new key identifier')
-        .option('-m, --mgmt-url <mgmtUrl>', 'the URL of the management server')
+        .option('-k, --key <key>', 'key for authenticating with Edge')
+        .option('-s, --secret <secret>', 'secret for authenticating with Edge')
+        .option('-i, --kid <kid>', 'new key identifier')
         .option('-t, --token <token>', 'OAuth token to use with management API')
+        .option('-r, --rotatekeyuri <rotatekeyuri>', 'Rotate  key url')
         .description('Rotate JWT Keys')
         .action((options) => {
             options.error = optionError(options);
             options.token = options.token || process.env.EDGEMICRO_SAML_TOKEN;
 
             if (!options.token) {
-                if (!options.username) {
-                    return options.error('username is required');
+                if (!options.key) {
+                    return options.error('key is required');
                 }
-
-                promptForPassword(options, (options) => {
-                    if (!options.password) {
-                        return options.error('password is required');
-                    }
-                });
+                if (!options.secret) {
+                    return options.error('secret is required');
+                }
             }
             if (!options.org) {
                 return options.error('org is required');
@@ -196,15 +186,13 @@ module.exports = function() {
             if (!options.env) {
                 return options.error('env is required');
             }
-            if (!options.mgmtUrl) {
-                return options.error('mgmtUrl is required');
+            if (!options.rotatekeyuri) {
+                return options.error('rotatekeyuri is required')
             }
-            if (!options.mgmtUrl.includes('http')) {
-                return options.error('runtimeUrl requires a prototcol http or https')
+            if (options.rotatekeyuri && !options.rotatekeyuri.includes('http')) {
+                return options.error('rotatekeyuri requires a prototcol http or https')
             }
-
-            rotatekey.rotatekey(options, () => {});
-            
+            rotatekey.rotatekey(options);
         });
 
     app.parse(process.argv);

--- a/cli/cmd.js
+++ b/cli/cmd.js
@@ -472,11 +472,11 @@ const setup = function setup() {
         .command('upgradekvm')
         .option('-o, --org <org>', 'the organization')
         .option('-e, --env <env>', 'the environment')
-        .option('-u, --username <user>', 'username of the organization admin')
-        .option('-p, --password <password>', 'password of the organization admin')
+        .option('-k, --key <key>', 'key for authenticating with Edge')
+        .option('-s, --secret <secret>', 'secret for authenticating with Edge')
         .option('-t, --token <token>', 'OAuth token to use with management API')
         .option('-v, --virtualhost <virtualhost>', 'virtual host of the proxy')
-        .option('-b, --baseuri <baseuri>', 'baseuri for management apis')
+        .option('-p, --proxyuri <proxyuri>', 'proxyuri for edgeauth proxy')
         .description('upgrade kvm to support JWT Key rotation')
         .action((options) => {
             options.error = optionError(options);
@@ -487,18 +487,19 @@ const setup = function setup() {
                 return options.error('env is required');
             }
             if (options.token) {
-                upgradekvm.upgradekvm(options, () => {});
+                upgradekvm.upgradekvm(options);
             } else {
-                if (!options.username) {
-                    return options.error('username is required');
+                if (!options.key) {
+                    return options.error('key is required');
                 }
-                promptForPassword(options, (options) => {
-                    if (!options.password) {
-                        return options.error('password is required');
-                    }
-                    upgradekvm.upgradekvm(options, () => {});
-                });
-            }
+                if (!options.secret) {
+                    return options.error('secret is required');
+                }
+                if (options.proxyuri && !options.proxyuri.includes('http')) {
+                    return options.error('proxyuri requires a prototcol http or https')
+                }
+                upgradekvm.upgradekvm(options);
+            } 
         });
 
     commander
@@ -540,32 +541,30 @@ const setup = function setup() {
         .command('rotatekey')
         .option('-o, --org <org>', 'the organization')
         .option('-e, --env <env>', 'the environment')
-        .option('-u, --username <user>', 'username of the organization admin')
-        .option('-p, --password <password>', 'password of the organization admin')
-        .option('-k, --kid <kid>', 'new key identifier')
+        .option('-k, --key <key>', 'key for authenticating with Edge')
+        .option('-s, --secret <secret>', 'secret for authenticating with Edge')
+        .option('-i, --kid <kid>', 'new key identifier')
         .option('-P,--prev-kid <oldkid>', 'previous key identifier')
-        .option('-b, --baseuri <baseuri>', 'baseuri for management apis')
+        .option('-r, --rotatekeyuri <rotatekeyuri>', 'rotate key url')
         .description('Rotate JWT Keys')
         .action((options) => {
             options.error = optionError(options);
-            if (!options.username) {
-                return options.error('username is required');
-            }
             if (!options.org) {
                 return options.error('org is required');
             }
             if (!options.env) {
                 return options.error('env is required');
             }
-            if (!options.kid) {
-                return options.error('kid is required');
+            if (!options.key) {
+                return options.error('key is required');
             }
-            promptForPassword(options, (options) => {
-                if (!options.password) {
-                    return options.error('password is required');
-                }
-                rotatekey.rotatekey(options, () => {});
-            })
+            if (!options.secret) {
+                return options.error('secret is required');
+            }
+            if (options.rotatekeyuri && !options.rotatekeyuri.includes('http')) {
+                return options.error('rotatekeyuri requires a prototcol http or https')
+            }
+            rotatekey.rotatekey(options);
         });
 
     commander

--- a/cli/lib/rotate-key.js
+++ b/cli/lib/rotate-key.js
@@ -5,7 +5,6 @@ const util = require("util");
 const debug = require("debug")("jwkrotatekey");
 //const commander = require('commander');
 const request = require("request");
-const async = require('async');
 const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
 
 const CONSOLE_LOG_TAG_COMP = 'microgateway rotate key';
@@ -27,349 +26,72 @@ function generateCredentialsObject(options) {
         };
     } else {
         return {
-            user: options.username,
-            pass: options.password
+            user: options.key,
+            pass: options.secret
         };
     }
 }
 
-function isCPS(property) {
-    var cpsenabled = false;
-	debug(property);
-    for (var p in property) {
-        if (property.hasOwnProperty(p)) {
-            if ( (property[p].name ===  "features.isCpsEnabled") && (typeof property[p].value !== "undefined") ) {
-				var b = property[p].value
-				if ( ((typeof b === 'string') && (b.toLocaleLowerCase() === 'true')) || ((typeof b === 'boolean') && b) ) {
-					cpsenabled = true;
-				}
-            }
-        }
-    }
-	return cpsenabled;	
-}
-
-function updateNonCPSKVM(options, serviceKey, newCertificate, newPublicKey, oldPublicKey) {
-	
-	var updatekvmuri = util.format("%s/v1/organizations/%s/environments/%s/keyvaluemaps/%s",
-    		options.baseuri, options.org, options.env, options.kvm);
-		
-    var payload = {
-        "name": options.kvm,
-        "encrypted": "true",
-        "entry": [{
-                "name": "private_key",
-                "value": serviceKey
-            },
-            {
-                "name": "private_key_kid",
-                "value": options.kid
-            },
-            {
-                "name": "public_key",
-                "value": newCertificate
-            },
-            {
-                "name": "public_key1",
-                "value": newPublicKey
-            },
-            {
-                "name": "public_key1_kid",
-                "value": options.kid
-            },
-            {
-                "name": "public_key2",
-                "value": oldPublicKey
-            },
-            {
-                "name": "public_key2_kid",
-                "value": options.oldkid
-            }
-        ]
-    };
-	debug(payload);	
-    request({
-       uri: updatekvmuri,
-       auth: generateCredentialsObject(options),
-       method: "POST",
-       json: payload
-    }, function(err, res /*, body */) {
-       if (err || res.statusCode > 299) {
-           writeConsoleLog('error',{component: CONSOLE_LOG_TAG_COMP},err);
-       } else {
-           writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP},"Key Rotation successfully completed!");
-       }
-    });	
-}
-
-function checkKVMEntry(options, key) {
-	var entryuri = util.format("%s/v1/organizations/%s/environments/%s/keyvaluemaps/%s/entries/%s",
-	options.baseuri, options.org, options.env, options.kvm, key);
-
-    request({
-        uri: entryuri,
-        auth: generateCredentialsObject(options),
-        method: "GET",
-    }, function(err, res /*, body */) {
-        if (err || res.statusCode > 299) return false;
-		else return true;
-    });						
-}
-
-function insertKVMEntry(options, key, value, cb) {
-	var entryuri = util.format("%s/v1/organizations/%s/environments/%s/keyvaluemaps/%s/entries",
-	options.baseuri, options.org, options.env, options.kvm);
-	var entry = {
-		"name": key,
-		"value": value
-	};
-    debug(entry);
-    request({
-        uri: entryuri,
-        auth: generateCredentialsObject(options),
-        method: "POST",
-		json: entry
-    }, function(err, res /*, body */) {
-        if (err || res.statusCode > 299) cb(err);
-		else cb(null, true);
-    });		
-	
-}
-
-function updateKVMEntry(options, key, value, cb) {
-	var entryuri = util.format("%s/v1/organizations/%s/environments/%s/keyvaluemaps/%s/entries/%s",
-	options.baseuri, options.org, options.env, options.kvm, key);
-	var entry = {
-		"name": key,
-		"value": value
-	};
-    debug(entry);
-    request({
-        uri: entryuri,
-        auth: generateCredentialsObject(options),
-        method: "POST",
-		json: entry
-    }, function(err, res /*, body */) {
-        if (err || res.statusCode > 299) cb(err);
-		else cb(null, true);
-    });	
-	
-}
-
-function updateOrInsertEntry (options, key, value, cb) {
-	if (checkKVMEntry(options, key)) {
-		debug("entry exists, updating..");
-		updateKVMEntry(options, key, value, function(err /*, result */){
-			if (err) cb(err);
-			else cb(null, true);
-		});
-	} else {
-		debug("entry does not exist. inserting entry...")
-		insertKVMEntry(options, key, value, function(err /*, result */){
-			if (err) cb(err);
-			else cb(null, true);
-		});
-	}
-}
-
-function updateCPSKVM(options, serviceKey, newCertificate, newPublicKey, oldPublicKey) {
-	var updatecpskvmuri = util.format("%s/v1/organizations/%s/environments/%s/keyvaluemaps/%s/entries/",
-                    options.baseuri, options.org, options.env,options.kvm);	
-	
-	async.parallel([
-		function (cb) {
-			var entry = {
-				name: "private_key",
-				value: serviceKey
-			};
-			debug(entry);
-            request({
-                uri: updatecpskvmuri+"private_key",
-                auth: generateCredentialsObject(options),
-                method: "POST",
-                json: entry
-            }, function(err, res, body) {
-                cb(err, body);
-            });						
-		},
-		function (cb) {
-			var entry = {
-				name: "private_key_kid",
-				value: options.kid
-			};
-			debug(entry);
-            request({
-                uri: updatecpskvmuri+"private_key_kid",
-                auth: generateCredentialsObject(options),
-                method: "POST",
-                json: entry
-            }, function(err, res, body) {
-                cb(err, body);
-            });						
-		},
-		function (cb) {
-			var entry = {
-				name: "public_key",
-				value: newCertificate
-			};
-			debug(entry);
-            request({
-                uri: updatecpskvmuri+"public_key",
-                auth: generateCredentialsObject(options),
-                method: "POST",
-                json: entry
-            }, function(err, res, body) {
-                cb(err, body);
-            });						
-		},
-		function (cb) {
-			var entry = {
-				name: "public_key1",
-				value: newPublicKey
-			};
-			debug(entry);
-            request({
-                uri: updatecpskvmuri+"public_key1",
-                auth: generateCredentialsObject(options),
-                method: "POST",
-                json: entry
-            }, function(err, res, body) {
-                cb(err, body);
-            });						
-		},
-		function (cb) {
-			var entry = {
-				name: "public_key1_kid",
-				value: options.kid
-			};
-			debug(entry);
-            request({
-                uri: updatecpskvmuri+"public_key1_kid",
-                auth: generateCredentialsObject(options),
-                method: "POST",
-                json: entry
-            }, function(err, res, body) {
-                cb(err, body);
-            });						
-		},
-		function (cb) {
-			updateOrInsertEntry(options, "public_key2", oldPublicKey, function(err, result) {
-				cb(err, result); 
-			});				
-		},
-		function (cb) {
-			updateOrInsertEntry(options, "public_key2_kid", options.oldkid, function(err, result) {
-				cb(err, result); 
-			});				
-		}												
-	], function (err /*, results */) {
-		if (err) {
-			writeConsoleLog('error',{component: CONSOLE_LOG_TAG_COMP},err);
-			process.exit(1);
-		} else {
-			writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP},"Key Rotation successfully completed!");
-		}
-    });
-}
-
 const RotateKey = function () {
-
+    
 }
 
 module.exports = function () {
-  return new RotateKey();
+return new RotateKey();
 }
 
-RotateKey.prototype.rotatekey = function rotatekey(options /*, cb */) {
+RotateKey.prototype.rotatekey = function rotatekey(options) {
+    writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP},"Generating New key/cert pair...");
+    createCert(function(err, newkeys) {
+        if (err){
+            writeConsoleLog('error',{component: CONSOLE_LOG_TAG_COMP},err);
+            process.exit(1);
+        } else{
+            const newServiceKey = newkeys.serviceKey;
+            const newCertificate = newkeys.certificate;
+            writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP},"Extract new public key");
+            pem.getPublicKey(newCertificate, function(err, newPublicKey) {
+                if (err) {
+                    writeConsoleLog('error',{component: CONSOLE_LOG_TAG_COMP},err);
+                    process.exit(1);
+                } else {
+                    updateOrInsertEntry(options, newServiceKey, newCertificate, newPublicKey.publicKey);
+                }
+            });	
+        }
+    });								
+}
 
-    options.baseuri = options.mgmtUrl || "https://api.enterprise.apigee.com";
-    options.kvm = "microgateway";
-    options.kid =  options.kid || "2";
-	options.oldkid = options["prevKid"] || "1";
-
-    async.series([
-    	function(cb) {
-		    var privateKeyURI = util.format("%s/v1/organizations/%s/environments/%s/keyvaluemaps/%s/entries/private_key",
-		        options.baseuri, options.org, options.env, options.kvm);
-		    writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP},"Checking if private key exists in the KVM...");
-		    request({
-		        uri: privateKeyURI,
-		        auth: generateCredentialsObject(options),
-		        method: "GET"
-		    }, function (err, resp, body) {
-		    	if (err) cb(err);
-				else cb(null,body);
-		    }); 		
-    	},
-		function(cb) {
-			writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP},"Checking for certificate...");
-            var publicKeyURI = util.format("https://%s-%s.apigee.net/edgemicro-auth/publicKey",
-                options.org, options.env);			
-            request({
-                uri: publicKeyURI,
-                auth: generateCredentialsObject(options),
-                method: "GET"
-            }, function (err, resp, body) {
-				if (err) cb(err);
-				else cb (null, body);	
-            });
-		}
-    ], function(err, results){
-    	if (err) {
-			writeConsoleLog('error',{component: CONSOLE_LOG_TAG_COMP},err);
-			process.exit(1);
-    	} else {
-    		var oldCertificate = results[1];
-			writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP},"Found Certificate");
-			//debug("Old Certificate: \n" + oldCertificate);
-			async.series([
-				function(cb) {
-					pem.getPublicKey(oldCertificate, function(e, oldPublicKey) {
-						if (e) cb(e);
-						else cb(null, oldPublicKey);
-					});
-					
-				}, 
-				function(cb) {
-					writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP},"Generating New key/cert pair...");
-					createCert(function(e, newkeys) {
-						if (e) cb(e);
-						else cb(null, newkeys);
-					});								
-				}
-			], function(e, res){
-				if (err) {
-					writeConsoleLog('error',{component: CONSOLE_LOG_TAG_COMP},e);
-					process.exit(1);
-				} else {
-					writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP},"Extract new public key");
-					var newCertificate = res[1].certificate;
-					pem.getPublicKey(newCertificate, function(ee, newkey) {
-						if (ee) {
-							writeConsoleLog('error',{component: CONSOLE_LOG_TAG_COMP},ee);
-							process.exit(1);
-						} else {
-							debug("Checking for CPS...");
-							var cpsuri = util.format("%s/v1/o/%s", options.baseuri, options.org);
-							request({
-                                uri: cpsuri,
-                                auth: generateCredentialsObject(options),
-                                method: "GET"
-                            }, function(eee, rs, body) {
-								var payload = JSON.parse(body);
-								var property = payload.properties.property;
-								if (isCPS(property)) {
-									debug("CPS is enabled");
-									updateCPSKVM(options, res[1].serviceKey, newCertificate, newkey.publicKey, res[0].publicKey);
-								} else {
-									debug("CPS is not enabled");
-									updateNonCPSKVM(options, res[1].serviceKey, newCertificate, newkey.publicKey, res[0].publicKey);
-								}
-							});							
-						}
-					});
-				}
-			});			
-    	}
+function updateOrInsertEntry(options, newServiceKey, newCertificate, newPublicKey){
+    let rotateKeyUri = null;
+    if (options.rotatekeyuri){
+        rotateKeyUri = options.rotatekeyuri; 
+    } else{
+        rotateKeyUri = util.format('https://%s-%s.apigee.net/edgemicro-auth/rotateKey', options.org, options.env);
+    }
+    const body = {
+        private_key_kid: options.kid,
+        private_key: newServiceKey,
+        public_key: newCertificate,
+        public_key1: newPublicKey
+    };
+    request({
+        uri: rotateKeyUri,
+        auth: generateCredentialsObject(options),
+        method: "POST",
+        json: body
+    },function (err, res) {
+        if (err){
+            writeConsoleLog('error',{component: CONSOLE_LOG_TAG_COMP},err);
+            process.exit(1);
+        } else {
+            if (res.statusCode === 200){
+                writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP}, res.body);
+                process.exit(0);
+            } else{
+                writeConsoleLog('error',{component: CONSOLE_LOG_TAG_COMP}, res.statusCode, res.body);
+                process.exit(1);
+            }
+        } 
     });
 }

--- a/cli/lib/upgrade-kvm.js
+++ b/cli/lib/upgrade-kvm.js
@@ -4,10 +4,7 @@ const pem = require("pem");
 const util = require("util");
 const debug = require("debug")("upgradekvm");
 const request = require("request");
-const async = require('async');
-
 const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
-
 const CONSOLE_LOG_TAG_COMP = 'microgateway upgrade kvm';
 
 function generateCredentialsObject(options) {
@@ -17,182 +14,79 @@ function generateCredentialsObject(options) {
         };
     } else {
         return {
-            user: options.username,
-            pass: options.password
+            user: options.key,
+            pass: options.secret
         };
     }
 }
 
-
-function updateKvmEntries(options, entries, publicKey) {
-
-    var updatekvmuri = util.format("%s/v1/organizations/%s/environments/%s/keyvaluemaps/%s/entries",
-    options.baseuri, options.org, options.env, options.kvm);
-
-    async.parallel([
-        function(cb) {
-
-            let payload =  {
-                "name": "private_key_kid",
-                "value": options.kid
-            }
-            let uri = entries.findIndex( item => item.name === payload.name) !== -1 ? updatekvmuri + '/'+  payload.name : updatekvmuri;
-            request({
-                uri: uri,
-                auth: generateCredentialsObject(options),
-                method: "POST",
-                json: payload
-            }, function(err, res , body ) {
-                if (err) {
-                    if ( cb ) { cb(err) } else process.exit(1);
-                    return;
-                } if (res.statusCode !== 200 && res.statusCode !== 201) {
-                    cb(new Error('Error updating KVM private_key_kid: '+ res.statusCode ))
-                } else {
-                    cb(null, body)
-                }
-            });
-            
-        },
-        function(cb) {
-            let payload = {
-                "name": "public_key1",
-                "value": publicKey.publicKey
-            }
-            let uri = entries.findIndex( item => item.name === payload.name) !== -1 ? updatekvmuri + '/'+  payload.name : updatekvmuri;
-            request({
-                uri: uri,
-                auth: generateCredentialsObject(options),
-                method: "POST",
-                json: payload
-            }, function(err, res , body ) {
-                if (err) {
-                    if ( cb ) { cb(err) } else process.exit(1);
-                    return;
-                } if (res.statusCode !== 200  && res.statusCode !== 201) {
-                    cb(new Error('Error updating KVM public_key1: '+ res.statusCode ))
-                } else {
-                    cb(null, body)
-                }
-            });
-        },
-        function(cb) {
-            let payload = {
-                "name": "public_key1_kid",
-                "value": options.kid
-            }
-            let uri = entries.findIndex( item => item.name === payload.name) !== -1 ? updatekvmuri + '/'+  payload.name : updatekvmuri;
-            request({
-                uri: uri,
-                auth: generateCredentialsObject(options),
-                method: "POST",
-                json: payload
-            }, function(err, res , body ) {
-                if (err) {
-                    if ( cb ) { cb(err) } else process.exit(1);
-                    return;
-                } if (res.statusCode !== 200  && res.statusCode !== 201) {
-                    cb(new Error('Error updating KVM public_key1_kid: '+ res.statusCode ))
-                } else {
-                    cb(null, body)
-                }
-            });
-        }
-    ], function(err, results) {
-        debug('error %s, private_key_kid %j, public_key1 %j, public_key1_kid %j', err,
-            results[0], results[1], results[2]);
-
-        if ( err ) {
-            writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP},"error upgrading KVM: "+ err);
+function updatekvm(options, baseUri){
+    writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP}, 'Updating KVM entries'); 
+    const body = {
+        public_key: options.publicKey1
+    };
+    request({
+        uri: baseUri+'upgradeKvm',
+        auth: generateCredentialsObject(options),
+        method: "POST",
+        json: body
+    },function (err, res) {
+        if (err){
+            writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP},"Error in upgrade kvm: "+ err);
             process.exit(1);
-        }
-        else {
-            writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP},"KVM update complete");
-            process.exit(0);
-        }
-       
+        } else {
+            if (res.statusCode === 200){
+                writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP}, res.body);
+                process.exit(0);
+            } else{
+                writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP}, res.statusCode, res.body);
+                process.exit(1);
+            }
+        } 
     });
 }
-
-function readKvmEntries(options, publicKey) {
-    
-    var getkvmuri = util.format("%s/v1/organizations/%s/environments/%s/keyvaluemaps/%s",
-    options.baseuri, options.org, options.env, options.kvm);
-
-
-    writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP},"Reading kvm entries from %s ", getkvmuri);
-    request({
-        uri: getkvmuri,
-        auth: generateCredentialsObject(options),
-        method: "GET"
-    }, function(err, res, body) {
-        if (err) {
-            writeConsoleLog('error',{component: CONSOLE_LOG_TAG_COMP},err);
-        } else {
-            if ( res.statusCode === 200 ) {
-                try {
-                    body = JSON.parse(body);
-                    if (  body && Array.isArray(body.entry) ) {
-                        updateKvmEntries(options, body.entry, publicKey);
-                    } else {
-                        writeConsoleLog('error',{component: CONSOLE_LOG_TAG_COMP}, 'Cannot continue with unexpected data', body);
-                        process.exit(1);
-                    }
-                } catch (err) {
-                    writeConsoleLog('error',{component: CONSOLE_LOG_TAG_COMP}, 'Error in parsing data: %s, err: %s', body, err.message);
-                    process.exit(1);
-                }
-               
-            } else if ( res.statusCode === 404 ) {
-                writeConsoleLog('error',{component: CONSOLE_LOG_TAG_COMP}, 'KVM does not exist, Please run configure command');
-                process.exit(1);
-            } else {
-                writeConsoleLog('error',{component: CONSOLE_LOG_TAG_COMP}, 'Failed to read KVM values, statusCode: %d', res.statusCode);
-                process.exit(1);
-            }
-        }
-       }
-    );
-
-}
-
 
 const UpgradeKVM = function () {
 
 }
 
 module.exports = function () {
-  return new UpgradeKVM();
+    return new UpgradeKVM();
 }
 
 UpgradeKVM.prototype.upgradekvm = function upgradekvm(options, cb) {
-
-    options.baseuri = options.mgmtUrl || "https://api.enterprise.apigee.com";
-    options.kvm = 'microgateway';
-    options.kid = '1';
-    options.virtualhost = options.virtualhost || 'secure';    
-
-    var publicKeyURI = util.format('https://%s-%s.apigee.net/edgemicro-auth/publicKey', options.org, options.env);
-
+    let baseUri = null;
+    if (options.proxyuri){
+        baseUri = options.proxyuri.endsWith("/") ? options.proxyuri : options.proxyuri+'/';   
+    } else{
+        baseUri = util.format('https://%s-%s.apigee.net/edgemicro-auth/', options.org, options.env);
+    }
     writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP},"Checking for certificate...");
     request({
-        uri: publicKeyURI,
+        uri: baseUri+'publicKey',
         auth: generateCredentialsObject(options),
         method: "GET"
-    }, function(err, res, body) {
+    }, function(err, res) {
         if (err) {
             writeConsoleLog('error',{component: CONSOLE_LOG_TAG_COMP},err);
+            process.exit(1);
         } else {
-            writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP},"Certificate found!");
-            pem.getPublicKey(body, function(err, publicKey) {
-                writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP},publicKey.publicKey);
-                
-                readKvmEntries(options, publicKey);
-                
-            });
+            if(res.statusCode === 200 && res.body !== 'null'){
+                writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP},"Certificate found!");
+                pem.getPublicKey(res.body, function(err, publicKey) {
+                    if (err) {
+                        writeConsoleLog('error',{component: CONSOLE_LOG_TAG_COMP},err);
+                        process.exit(1);
+                    } else {
+                        writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP},publicKey.publicKey);
+                        options.publicKey1 = publicKey.publicKey;
+                        updatekvm(options, baseUri)
+                    }
+                });
+            } else{
+                writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP}, res.statusCode, res.body ); 
+                process.exit(1);
+            }
         }
-       }
-    );
-
+    });
 }
-


### PR DESCRIPTION
Consume endpoint '/upgradeKvm' to upgrade kvm.
Consume endpoint '/rotateKey' to rotate key.
Remove redundant code.
Add key and secret keys for authorization of upgradekvm and rotatekey cli calls.

upgradekvm cmd cli params :
  -o = org
  -e = env
  -k = key
  -s = secret
  -p = proxyuri

rotatekey command cli params:
  -o = org
  -e = env
  -k = key
  -s = secret
  -i = kid (optional)
  -r = rotatekeyuri