### PR TITLE
156560067 merge env values in config.

### DIFF
--- a/lib/agent-config.js
+++ b/lib/agent-config.js
@@ -3,6 +3,10 @@ const edgeConfig = require('microgateway-config');
 const agent = require('./server')();
 const fs = require('fs');
 const assert = require('assert');
+const debug = require('debug')('gateway:init');
+
+const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
+const CONSOLE_LOG_TAG_COMP = 'microgateway agent-config';
 //const path = require('path');
 //const cluster = require('cluster');
 
@@ -19,7 +23,31 @@ module.exports = function configureAndStart(options, cb) {
 const getConfigStart = function getConfigStart(options, cb) {
   fs.exists(options.target, (exists) => {
     if (exists) {
-      const config = edgeConfig.load({ source: options.target });
+      let config = edgeConfig.load({ source: options.target });
+      // merge env values into the config
+      try {
+        let configStr = JSON.stringify(config);
+        let envRegx = RegExp('<E>.+?<\/E>','g');   
+        let envKeys = configStr.match(envRegx);
+        if ( envKeys && envKeys.length > 0) {
+          envKeys.forEach( key => {
+            let envKey = key.replace('<E>','').replace("</E>",''); // remove env tags
+            let value = process.env[envKey];
+            if ( value ) {
+              debug('Replacing: %s by en value: %s', key, `${value}`);
+              configStr = configStr.replace(key,`${value}`)
+            } else {
+              let err = new Error('No env variable '+ envKey +' available to replace in config');
+              writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP}, err);
+            }
+          })
+          config = JSON.parse(configStr);
+        }
+      } catch(err) {
+        writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP},'Error in merging env values in the config', err)
+      }
+      
+    
       const keys = {key: config.analytics.key, secret: config.analytics.secret};
       startServer(keys, options.pluginDir, config, cb);
     } else {


### PR DESCRIPTION
Make yaml config values configurable through environment variables by adding
env variable inside tags '<E>' and '</E>'.

Replace all the values in the config if env variable is available.

A sample config could be:

targets:
  - ssl:
      client:
        key: <E>TARGETS_SSL_CLIENT_KEY</E>
        cert: <E>TARGETS_SSL_CLIENT_CERT</E>
        passphrase: <E>TARGETS_SSL_CLIENT_PASSPHRASE</E>
        rejectUnauthorized: true