### PR TITLE
Remove heapdump dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "gulp": "^4.0.2",
     "gulp-shell": "^0.6.5",
     "gulp-sourcemaps": "^1.5.2",
-    "heapdump": "^0.3.15",
     "jshint-stylish": "^2.2.1",
     "minimist": "^1.1.1",
     "mocha": "^5.2.0",


### PR DESCRIPTION
Remove heapdump dependency from project.
When running emg in heapdump mode manually install with command 'npm i heapdump -D'