### PR TITLE
Remove unused options.

### DIFF
--- a/cli/cmd-private.js
+++ b/cli/cmd-private.js
@@ -83,23 +83,17 @@ module.exports = function() {
         .option('-e, --env <env>', 'the environment')
         .option('-k, --key <key>', 'key for authenticating with Edge')
         .option('-s, --secret <secret>', 'secret for authenticating with Edge')
-        .option('-v, --virtualhost <virtualhost>', 'virtual host of the proxy')
-        .option('-t, --token <token>', 'OAuth token to use with management API')
         .option('-p, --proxyuri <proxyuri>', 'proxyuri for edgeauth proxy')
         .description('upgrade kvm to support JWT Key rotation')
         .action((options) => {
             options.error = optionError(options);
-            options.token = options.token || process.env.EDGEMICRO_SAML_TOKEN;
 
-            if (!options.token) {
-                if (!options.key) {
-                    return options.error('key is required');
-                }
-                if (!options.secret) {
-                    return options.error('secret is required');
-                }
+            if (!options.key) {
+                return options.error('key is required');
             }
-
+            if (!options.secret) {
+                return options.error('secret is required');
+            }
             if (!options.org) {
                 return options.error('org is required');
             }
@@ -165,20 +159,15 @@ module.exports = function() {
         .option('-k, --key <key>', 'key for authenticating with Edge')
         .option('-s, --secret <secret>', 'secret for authenticating with Edge')
         .option('-i, --kid <kid>', 'new key identifier')
-        .option('-t, --token <token>', 'OAuth token to use with management API')
-        .option('-r, --rotatekeyuri <rotatekeyuri>', 'Rotate  key url')
+        .option('-r, --rotatekeyuri <rotatekeyuri>', 'Rotate key url')
         .description('Rotate JWT Keys')
         .action((options) => {
             options.error = optionError(options);
-            options.token = options.token || process.env.EDGEMICRO_SAML_TOKEN;
-
-            if (!options.token) {
-                if (!options.key) {
-                    return options.error('key is required');
-                }
-                if (!options.secret) {
-                    return options.error('secret is required');
-                }
+            if (!options.key) {
+                return options.error('key is required');
+            }
+            if (!options.secret) {
+                return options.error('secret is required');
             }
             if (!options.org) {
                 return options.error('org is required');

--- a/cli/cmd.js
+++ b/cli/cmd.js
@@ -474,8 +474,6 @@ const setup = function setup() {
         .option('-e, --env <env>', 'the environment')
         .option('-k, --key <key>', 'key for authenticating with Edge')
         .option('-s, --secret <secret>', 'secret for authenticating with Edge')
-        .option('-t, --token <token>', 'OAuth token to use with management API')
-        .option('-v, --virtualhost <virtualhost>', 'virtual host of the proxy')
         .option('-p, --proxyuri <proxyuri>', 'proxyuri for edgeauth proxy')
         .description('upgrade kvm to support JWT Key rotation')
         .action((options) => {
@@ -486,20 +484,16 @@ const setup = function setup() {
             if (!options.env) {
                 return options.error('env is required');
             }
-            if (options.token) {
-                upgradekvm.upgradekvm(options);
-            } else {
-                if (!options.key) {
-                    return options.error('key is required');
-                }
-                if (!options.secret) {
-                    return options.error('secret is required');
-                }
-                if (options.proxyuri && !options.proxyuri.includes('http')) {
-                    return options.error('proxyuri requires a prototcol http or https')
-                }
-                upgradekvm.upgradekvm(options);
-            } 
+            if (!options.key) {
+                return options.error('key is required');
+            }
+            if (!options.secret) {
+                return options.error('secret is required');
+            }
+            if (options.proxyuri && !options.proxyuri.includes('http')) {
+                return options.error('proxyuri requires a prototcol http or https')
+            }
+            upgradekvm.upgradekvm(options);
         });
 
     commander
@@ -544,7 +538,6 @@ const setup = function setup() {
         .option('-k, --key <key>', 'key for authenticating with Edge')
         .option('-s, --secret <secret>', 'secret for authenticating with Edge')
         .option('-i, --kid <kid>', 'new key identifier')
-        .option('-P,--prev-kid <oldkid>', 'previous key identifier')
         .option('-r, --rotatekeyuri <rotatekeyuri>', 'rotate key url')
         .description('Rotate JWT Keys')
         .action((options) => {

--- a/cli/lib/rotate-key.js
+++ b/cli/lib/rotate-key.js
@@ -20,16 +20,10 @@ function createCert(cb) {
 }
 
 function generateCredentialsObject(options) {
-    if (options.token) {
-        return {
-            "bearer": options.token
-        };
-    } else {
-        return {
-            user: options.key,
-            pass: options.secret
-        };
-    }
+    return {
+        user: options.key,
+        pass: options.secret
+    };
 }
 
 const RotateKey = function () {

--- a/cli/lib/upgrade-kvm.js
+++ b/cli/lib/upgrade-kvm.js
@@ -8,16 +8,10 @@ const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
 const CONSOLE_LOG_TAG_COMP = 'microgateway upgrade kvm';
 
 function generateCredentialsObject(options) {
-    if (options.token) {
-        return {
-            "bearer": options.token
-        };
-    } else {
-        return {
-            user: options.key,
-            pass: options.secret
-        };
-    }
+    return {
+        user: options.key,
+        pass: options.secret
+    };
 }
 
 function updatekvm(options, baseUri){


### PR DESCRIPTION
Removed below options for upgradeKvm and rotateKey commands

upgradeKvm :
  -t = OAuth token to use with management API
  -v = virtual host of the proxy

rotateKey :
  -P = previous key identifier

Private commands

upgradeKvm :
  -t = OAuth token to use with management API
  -v = virtual host of the proxy

rotateKey :
  -t = OAuth token to use with management API