### PR TITLE
For enable analytics

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -76,6 +76,10 @@ function _reorderPlugins(dirs, config) {
 
   // enable metrics plugin
   if ( config.edgemicro.useMetrics ) {
+    // 'metrics' uses 'analytics' plugin, hence enable 'analytics'
+    if(defaultPlugins[0] !== analytics ){
+      defaultPlugins = [ analytics ]
+    }
     defaultPlugins.push('metrics')
   } 
 

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -67,10 +67,17 @@ function _reorderPlugins(dirs, config) {
 
   let defaultPlugins = [ analytics ];
 
+  // disable analytics plugin based on configuration
+  if(config.edgemicro.hasOwnProperty('enableAnalytics')){
+    if(!config.edgemicro.enableAnalytics){
+      defaultPlugins = [];
+    }
+  }
+
   // enable metrics plugin
   if ( config.edgemicro.useMetrics ) {
     defaultPlugins.push('metrics')
-  }
+  } 
 
   const sequence = config.edgemicro.plugins.sequence || [];
 


### PR DESCRIPTION
170708621 new config for analytics plugin

Remove analytics plugin from default plugins list based on below config param in config.yaml file
edgemicro:
  enableAnalytics: true/false

If enableAnalytics param is not defined, analytics plugin exists in the default plugins list.
Add 'analytics' plugin to default plugins list, if 'metrics' plugin is enabled.