### PR TITLE
 169810710 Handle caching of key and secret correctly

### DIFF
--- a/cli/lib/gateway.js
+++ b/cli/lib/gateway.js
@@ -124,7 +124,6 @@ Gateway.prototype.start = (options,cb) => {
         config.uid = uuid();
         initializeMicroGatewayLogging(config, options);
         var opt = {};
-        delete args.keys;
         //set pluginDir
         if (!args.pluginDir) {
             if (config.edgemicro.plugins && config.edgemicro.plugins.dir) {

--- a/lib/agent-config.js
+++ b/lib/agent-config.js
@@ -25,13 +25,13 @@ const getConfigStart = function getConfigStart(options, cb) {
   fs.exists(options.target, (exists) => {
     if (exists) {
       let config = edgeConfig.load({ source: options.target });
+      _mergeKeys(config,options.keys);
       
       if(options.metrics){
         config.edgemicro.useMetrics = true;
       }
       
-      const keys = {key: config.analytics.key, secret: config.analytics.secret};
-      startServer(keys, options.pluginDir, config, cb);
+      startServer(options.keys, options.pluginDir, config, cb);
     } else {
       return cb(options.target+" must exist")
     }
@@ -42,4 +42,30 @@ const startServer = function startServer(keys, pluginDir,config, cb) {
   agent.start(keys, pluginDir, config, function (err) {
     cb(err, agent, config);
   });
+}
+
+
+/**
+ * merge downloaded config with keys
+ * @param mergedConfig
+ * @param keys
+ * @private
+ */
+function _mergeKeys(mergedConfig, keys) {
+  assert(keys.key, 'key is missing');
+  assert(keys.secret, 'secret is missing');
+  // copy keys to analytics section
+  if (!mergedConfig.analytics) {
+      mergedConfig.analytics = {};
+  }
+  mergedConfig.analytics.key = keys.key;
+  mergedConfig.analytics.secret = keys.secret;
+  // copy keys to quota section
+  if (mergedConfig.quota) {
+      Object.keys(mergedConfig.quota).forEach(function(name) {
+          const quota = mergedConfig.quota[name];
+          quota.key = keys.key;
+          quota.secret = keys.secret;
+      });
+  }
 }


### PR DESCRIPTION
 Add key and secret from the cli options in the args object which is passed to the agent-config
 Pass key and secret from the agent-config to all workers and plugins