### PR TITLE
170708621 new config for analytics plugin

### DIFF
--- a/cli/lib/gateway.js
+++ b/cli/lib/gateway.js
@@ -84,7 +84,8 @@ Gateway.prototype.start = (options,cb) => {
         keys: keys,
         localproxy: localproxy,
         org: options.org,
-        env: options.env
+        env: options.env,
+        metrics: options.metrics !== undefined ? options.metrics : false
     }
 
     const startSynchronizer = (err, config) => {

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -67,8 +67,19 @@ function _reorderPlugins(dirs, config) {
 
   let defaultPlugins = [ analytics ];
 
+  // disable analytics plugin based on configuration
+  if(config.edgemicro.hasOwnProperty('enableAnalytics')){
+    if(!config.edgemicro.enableAnalytics){
+      defaultPlugins = [];
+    }
+  }
+
   // enable metrics plugin
   if ( config.edgemicro.useMetrics ) {
+    // 'metrics' uses 'analytics' plugin, hence enable 'analytics'
+    if(defaultPlugins[0] !== analytics ){
+      defaultPlugins = [ analytics ]
+    }
     defaultPlugins.push('metrics')
   }
 


### PR DESCRIPTION
Remove analytics plugin from default plugins list based on below config param in config.yaml file

  edgemicro:
    enableAnalytics: true/false

If enableAnalytics param is not defined or if metrics plugin is enabled, then analytics plugin exists in the default plugins list.
Include metrics option in configOptions

Add 'analytics' plugin to default plugins list, if 'metrics' plugin is enabled.