### PR TITLE
178423436 Handle display of key,secret in node processes correctly

### DIFF
--- a/cli/cmd.js
+++ b/cli/cmd.js
@@ -147,8 +147,8 @@ const setup = function setup() {
         .description('start the gateway based on configuration')
         .action((options) => {
             options.error = optionError(options);
-            options.secret = options.secret || process.env.EDGEMICRO_SECRET;
-            options.key = options.key || process.env.EDGEMICRO_KEY;
+            options.secret = options.secret;
+            options.key = options.key;
             options.org = options.org || process.env.EDGEMICRO_ORG;
             options.env = options.env || process.env.EDGEMICRO_ENV;
             options.processes = options.processes || process.env.EDGEMICRO_PROCESSES;
@@ -173,10 +173,10 @@ const setup = function setup() {
 
                     });
             }
-            if (!options.key && !process.env.EDGEMICRO_LOCAL) {
+            if (!options.key && !process.env.EDGEMICRO_LOCAL && !process.env.EDGEMICRO_KEY) {
                 return options.error('key is required');
             }
-            if (!options.secret && !process.env.EDGEMICRO_LOCAL) {
+            if (!options.secret && !process.env.EDGEMICRO_LOCAL && !process.env.EDGEMICRO_SECRET) {
                 return options.error('secret is required');
             }
             if (!options.org) {

--- a/cli/lib/gateway.js
+++ b/cli/lib/gateway.js
@@ -59,16 +59,15 @@ Gateway.prototype.start = (options,cb) => {
 
     const source = configLocations.getSourcePath(options.org, options.env, options.configDir);
     const cache = configLocations.getCachePath(options.org, options.env, options.configDir);
-    const configurl = options.configUrl;   
+    const configurl = options.configUrl;
     
     const keys = {
-        key: options.key,
-        secret: options.secret
+        key: options.key || process.env.EDGEMICRO_KEY,
+        secret: options.secret || process.env.EDGEMICRO_SECRET
     };
 
     var args = {
         target: cache,
-        keys: keys,
         pluginDir: options.pluginDir
     };
 
@@ -131,6 +130,11 @@ Gateway.prototype.start = (options,cb) => {
                 args.pluginDir = path.resolve(config.edgemicro.plugins.dir);
             }
         }
+
+        if(options.key && options.secret){
+            args.keys = keys;
+        }
+
         args['metrics'] = options.metrics;
         opt.args = [JSON.stringify(args)];
         opt.timeout = 10;

--- a/lib/agent-config.js
+++ b/lib/agent-config.js
@@ -25,13 +25,27 @@ const getConfigStart = function getConfigStart(options, cb) {
   fs.exists(options.target, (exists) => {
     if (exists) {
       let config = edgeConfig.load({ source: options.target });
-      _mergeKeys(config,options.keys);
+      let keys = {};
+
+      if((process.env.EDGEMICRO_KEY && process.env.EDGEMICRO_SECRET) && !options.keys){
+          keys  = {
+            key: process.env.EDGEMICRO_KEY,
+            secret: process.env.EDGEMICRO_SECRET
+          }
+      }else{
+          keys = {
+            key: options.keys.key,
+            secret: options.keys.secret
+          } 
+      }
+
+      _mergeKeys(config,keys);
       
       if(options.metrics){
         config.edgemicro.useMetrics = true;
       }
       
-      startServer(options.keys, options.pluginDir, config, cb);
+      startServer(keys, options.pluginDir, config, cb);
     } else {
       return cb(options.target+" must exist")
     }


### PR DESCRIPTION
  Added condition that if key and secret are stored in environment variables,
  these values will be directly fetched at worker level thus avoiding values to get displayed in the node child process
  Else if passed in command line arguments, it will get displayed in the node process