### PR TITLE
b/183057665: make sock and pid file configurable - 1st approach

### DIFF
--- a/config/locations.js
+++ b/config/locations.js
@@ -40,15 +40,15 @@ module.exports = {
       return path.join(this.homeDir, org + "-" + env + "-" + cacheFile);
     }
   },
-  getIPCFilePath: function getIPCFilePath() {
+  getIPCFilePath: function getIPCFilePath(customDir) {
     if (!isWin) {
-      return path.join(process.cwd(), defaultIPCFileName + '.sock');
+      return path.join(customDir || process.cwd(), defaultIPCFileName + '.sock');
     } else {
-      return path.join('\\\\?\\pipe', process.cwd(), defaultIPCFileName);
+      return path.join('\\\\?\\pipe', customDir || process.cwd(), defaultIPCFileName);
     }
   },
-  getPIDFilePath: function getPIDFilePath() {
-    return path.join(process.cwd(), defaultIPCFileName + '.pid');
+  getPIDFilePath: function getPIDFilePath(customDir) {
+    return path.join(customDir || process.cwd(), defaultIPCFileName + '.pid');
   },  
   homeDir: homeDir,
   defaultDir: configDir,


### PR DESCRIPTION
This is the first solution of this issue. It allows user to configure sock and pid file path in config yaml file

**Disclaimer**: With this method, custom path will be applied in both host server and docker instance uniformly. Customer can't have different path in server and different path in docker instance.