### PR TITLE
183990345 Fix logging to console issue in docker

### DIFF
--- a/kubernetes/docker/edgemicro/entrypoint.sh
+++ b/kubernetes/docker/edgemicro/entrypoint.sh
@@ -123,12 +123,33 @@ start_edge_micro() {
   echo $CMDSTRING
 }
 
-start_edge_micro  2>&1 | tee -i $LOG_FILE
+if [[ -n "$LOG_CONSOLE_OUTPUT_TO_FILE"  ]]
+  then
+    if [ "$LOG_CONSOLE_OUTPUT_TO_FILE" = "false" ] || [ "$LOG_CONSOLE_OUTPUT_TO_FILE" = "False" ] || [ "$LOG_CONSOLE_OUTPUT_TO_FILE" = "FALSE" ]
+      then
+        start_edge_micro  2>&1
+      else
+        start_edge_micro  2>&1 | tee -i $LOG_FILE
+    fi
+  else
+    start_edge_micro  2>&1 | tee -i $LOG_FILE
+fi
 
 # SIGUSR1-handler
 my_handler() {
   echo "my_handler" >> /tmp/entrypoint.log
-  /bin/bash -c "cd ${APIGEE_ROOT} && edgemicro stop" 2>&1  | tee -i $LOG_FILE
+
+  if [[ -n "$LOG_CONSOLE_OUTPUT_TO_FILE"  ]]
+    then
+      if [ "$LOG_CONSOLE_OUTPUT_TO_FILE" = "false" ] || [ "$LOG_CONSOLE_OUTPUT_TO_FILE" = "False" ] || [ "$LOG_CONSOLE_OUTPUT_TO_FILE" = "FALSE" ]
+        then
+          /bin/bash -c "cd ${APIGEE_ROOT} && edgemicro stop" 2>&1
+        else
+          /bin/bash -c "cd ${APIGEE_ROOT} && edgemicro stop" 2>&1  | tee -i $LOG_FILE
+      fi
+    else
+          /bin/bash -c "cd ${APIGEE_ROOT} && edgemicro stop" 2>&1  | tee -i $LOG_FILE
+  fi
 }
 
 # SIGTERM-handler
@@ -143,7 +164,19 @@ term_handler() {
     echo "term_handler_sleep $EDGEMICRO_STOP_DELAY" >> /tmp/entrypoint.log
     sleep $EDGEMICRO_STOP_DELAY
   fi
-  /bin/bash -c "cd ${APIGEE_ROOT} && edgemicro stop"  2>&1 | tee -i $LOG_FILE
+
+  if [[ -n "$LOG_CONSOLE_OUTPUT_TO_FILE"  ]]
+    then
+      if [ "$LOG_CONSOLE_OUTPUT_TO_FILE" = "false" ] || [ "$LOG_CONSOLE_OUTPUT_TO_FILE" = "False" ] || [ "$LOG_CONSOLE_OUTPUT_TO_FILE" = "FALSE" ]
+        then
+          /bin/bash -c "cd ${APIGEE_ROOT} && edgemicro stop"  2>&1
+        else
+          /bin/bash -c "cd ${APIGEE_ROOT} && edgemicro stop"  2>&1 | tee -i $LOG_FILE
+      fi
+    else
+      /bin/bash -c "cd ${APIGEE_ROOT} && edgemicro stop"  2>&1 | tee -i $LOG_FILE
+  fi
+  
   exit 143; # 128 + 15 -- SIGTERM
 }
 


### PR DESCRIPTION
Optimized code for docker to stop logging into edgemicro.log file by passing a new variable to docker run “LOG_CONSOLE_OUTPUT_TO_FILE”
If this variable is set to “false” OR "False" OR "FALSE", it will not log anything in edgemicro.log file else will log into it.
Defaults to false (Will log to edgemicro.log by default)