### PR TITLE
188492065 Remove support for NodeJS ver 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ jobs:
     - stage: coverage_tests
       language: node_js
       node_js:
-        - '8'
-    - # stage name not required, will continue to use `test`
-      language: node_js
-      node_js:
         - '10'
     - # stage name not required, will continue to use `test`
       language: node_js
@@ -16,13 +12,6 @@ jobs:
       language: node_js
       node_js:
         - '14'
-    - stage: e2e-v8  # these can be made parallel by using different accounts or names
-      language: node_js
-      node_js:
-        - '8'
-      script:
-        - npm install -g js-yaml
-        - bash ./test-functional/e2evars.sh
     - stage: e2e-v10
       language: node_js
       node_js:

--- a/cli/edgemicro
+++ b/cli/edgemicro
@@ -24,8 +24,8 @@
 var edgemicroVersion = require('../package.json').version;
 const writeConsoleLog = require('microgateway-core').Logging.writeConsoleLog;
 const version = process.version;
-const ltsVersion = 8;
-const experimental = ["v7", "v9","v11","v13"];
+const ltsVersion = 10;
+const experimental = ["v11","v13"];
 const latest = 14;
 
 const CONSOLE_LOG_TAG_COMP = 'microgateway edgemicro';
@@ -44,8 +44,8 @@ for (var ver in experimental) {
 }
 var majorVersion = parseInt(version.split(".")[0].replace("v", ""));
 
-if (majorVersion == 8) {
-    writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP},"Current NodeJS version is " + version + ".  Note, v8.x.x will be out of support soon. For more details, please see https://docs.apigee.com/release/notes/edge-microgateway-release-notes-0");
+if (majorVersion >= 10) {
+    writeConsoleLog('log',{component: CONSOLE_LOG_TAG_COMP},"Current NodeJS version is " + version + ".");
 }
 
 if (majorVersion < ltsVersion || majorVersion > latest) {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   ],
   "author": "Kevin Swiber <kswiber@gmail.com>",
   "engines": {
-    "node": "^8 || ^10 || ^12 || ^14",
+    "node": "^10 || ^12 || ^14",
     "npm": ">=3.10.8"
   },
   "cpu": [


### PR DESCRIPTION
Starting with release 3.2.2, NodeJS 8 will no longer be supported.
https://docs.apigee.com/release/notes/edge-microgateway-release-notes-0

Edge Microgateway supports NodeJS versions 10, 12, and 14.