### PR TITLE
191352643 Fix NodeJS vulnerability in docker

### DIFF
--- a/kubernetes/docker/edgemicro/Dockerfile
+++ b/kubernetes/docker/edgemicro/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-buster-slim
+FROM node:12.22-buster-slim
 
 COPY installnode.sh /tmp
 COPY --chown=101:101 installedgemicro.sh /tmp


### PR DESCRIPTION
  Optimised the dockerfile to build the docker image with 12.22v of node-buster-slim, which will have upgraded NodeJS version@12.22